### PR TITLE
Merge stack-nix.yaml and stack.yaml.

### DIFF
--- a/stack-nix.yaml
+++ b/stack-nix.yaml
@@ -1,9 +1,0 @@
-resolver: nightly-2018-02-28
-nix:
-  enable: true
-  packages:
-    - nodejs-9_x
-    - zlib
-packages:
-  - inline-javascript
-  - inline-javascript-examples

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,10 @@
 resolver: nightly-2018-02-28
+
 packages:
   - inline-javascript
   - inline-javascript-examples
+
+nix:
+  packages:
+    - nodejs-9_x
+    - zlib


### PR DESCRIPTION
Without `enable: true` hard coded in the stack.yaml, users can decide
whether `--nix` should be on or not.