### PR TITLE
Add template params to quasiquoter

### DIFF
--- a/inline-js/package.yaml
+++ b/inline-js/package.yaml
@@ -9,7 +9,6 @@ github: tweag/inline-js
 
 extra-source-files:
   - LICENSE
-  - package.yaml
 
 ghc-options:
   - -Wall

--- a/inline-js/package.yaml
+++ b/inline-js/package.yaml
@@ -22,6 +22,7 @@ ghc-options:
 dependencies:
   - base
   - inline-js-core
+  - language-javascript
   - template-haskell
   - text
 

--- a/inline-js/src/Language/JavaScript/Inline.hs
+++ b/inline-js/src/Language/JavaScript/Inline.hs
@@ -1,38 +1,50 @@
-{-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE CPP #-}
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE ExistentialQuantification #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE NamedFieldPuns #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE ViewPatterns #-}
 
 module Language.JavaScript.Inline
   ( js
   ) where
 
-import Data.Text as Text
+import qualified Data.Text as Text
 import qualified Language.Haskell.TH as TH
 import Language.Haskell.TH (Q)
 import Language.Haskell.TH.Quote (QuasiQuoter(..))
+import Language.Haskell.TH.Syntax (liftString)
 import Language.JavaScript.Inline.Command (eval)
 import Language.JavaScript.Inline.JSCode (codeFromString)
+import Language.JavaScript.Inline.JSON (encodeText)
+import Language.JavaScript.Parser.Lexer (Token(..), alexTestTokeniser)
 
 js :: QuasiQuoter
 js =
   QuasiQuoter
-    { quoteExp = expQQ
+    { quoteExp = expQuasiQuoter
     , quotePat = error "Language.JavaScript.Inline: quotePat"
     , quoteType = error "Language.JavaScript.Inline: quoteType"
     , quoteDec = error "Language.JavaScript.Inline: quoteDec"
     }
 
-expQQ :: String -> Q TH.Exp
-expQQ input = [|\session -> eval session (codeFromString $ Text.pack input)|]
+-- JSCode -> JSSession -> IO JSCode
+expQuasiQuoter :: String -> Q TH.Exp
+expQuasiQuoter input =
+  let tokens = either error id $ alexTestTokeniser input
+      antiquotedParameterNames =
+        [name | IdentifierToken {tokenLiteral = ('$':name)} <- tokens]
+   in do [|\session -> do
+             void $
+               $(evaluateAll $
+                 fmap nameToJSVarDeclaration $ antiquotedParameterNames)
+             eval session (codeFromString $ Text.pack input)|]
+
+-- [JSCode] -> IO ()
+evaluateAll :: [Q TH.Exp] -> Q TH.Exp
+evaluateAll = foldr (\dec acc -> [|$(acc) >> eval session $(dec)|]) [|pure ()|]
+
+-- String -> JSCode
+nameToJSVarDeclaration :: String -> Q TH.Exp
+nameToJSVarDeclaration name =
+  let variableReference :: Q TH.Exp
+      variableReference = TH.varE $ TH.mkName name
+   in [|codeFromString $
+        "let $" <> $(liftString name) <> " = " <>
+        encodeText $(variableReference) <>
+        ";"|]

--- a/inline-js/tests/Tests/Quotation.hs
+++ b/inline-js/tests/Tests/Quotation.hs
@@ -10,7 +10,6 @@ module Tests.Quotation
 import Control.Monad (void)
 import Language.JavaScript.Inline
 import Language.JavaScript.Inline.JSON
-import Language.JavaScript.Inline.Message
 import Language.JavaScript.Inline.Session
 import Test.Tasty (TestTree)
 import Test.Tasty.Hspec (it, shouldBe, testSpec)
@@ -25,3 +24,11 @@ tests =
     it "should concatenate two Strings" $ do
       result <- withJSSession defJSSessionOpts [js| "hello" + " goodbye" |]
       result `shouldBe` String "hello goodbye"
+    it "should take in a Haskell String and return it" $ do
+      let sentence = String "This is a String"
+      result <- withJSSession defJSSessionOpts [js| $sentence |]
+      result `shouldBe` sentence
+    it "should append a Haskell-inserted String to a JavaScript String" $ do
+      let sentence = String "Pineapple"
+      result <- withJSSession defJSSessionOpts [js| $sentence + " on pizza" |]
+      result `shouldBe` String "Pineapple on pizza"


### PR DESCRIPTION
Additional work to make templating parameters into the `js` quasiquoter work.