### PR TITLE
Include utils to make transports thread-safe

### DIFF
--- a/inline-js-core/src/Language/JavaScript/Inline/Session.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Session.hs
@@ -60,7 +60,7 @@ data JSSession = JSSession
 newJSSession :: JSSessionOpts -> IO JSSession
 newJSSession JSSessionOpts {..} = do
   t <- newProcessTransport nodeProcessTransportOpts
-  t' <- lockTransport t
+  t' <- lockSend t
   _msg_counter <- newMsgCounter
   _recv_map <- newIORef IntMap.empty
   pure

--- a/inline-js-core/src/Language/JavaScript/Inline/Session.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Session.hs
@@ -60,13 +60,7 @@ newJSSession :: JSSessionOpts -> IO JSSession
 newJSSession JSSessionOpts {..} = do
   t0 <- newProcessTransport nodeProcessTransportOpts
   t1 <- lockSend $ strictTransport t0
-  (_uniq_recv, t2) <-
-    uniqueRecv
-      (\buf ->
-         case runGetOrFail (fromIntegral <$> getWord32le) buf of
-           Right (_, _, r) -> Just r
-           _ -> Nothing)
-      t1
+  (_uniq_recv, t2) <- uniqueRecv (runGet (fromIntegral <$> getWord32le)) t1
   _msg_counter <- newMsgCounter
   pure
     JSSession

--- a/inline-js-core/src/Language/JavaScript/Inline/Transport/Utils.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Transport/Utils.hs
@@ -37,7 +37,7 @@ lockSend t = do
       }
 
 uniqueRecv ::
-     (LBS.ByteString -> Maybe Int)
+     (LBS.ByteString -> Int)
   -> Transport
   -> IO (Int -> IO LBS.ByteString, Transport)
 uniqueRecv mk t = do
@@ -47,12 +47,9 @@ uniqueRecv mk t = do
     let w = do
           ebuf <- try @SomeException $ recvData t
           case ebuf of
-            Right buf ->
-              case mk buf of
-                Just k -> do
-                  atomically $ modifyTVar' mv $ IMap.insert k buf
-                  w
-                _ -> pure ()
+            Right buf -> do
+              atomically $ modifyTVar' mv $ IMap.insert (mk buf) buf
+              w
             _ -> pure ()
      in w
   pure

--- a/inline-js-core/src/Language/JavaScript/Inline/Transport/Utils.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Transport/Utils.hs
@@ -42,6 +42,7 @@ uniqueRecv ::
   -> IO (Int -> IO LBS.ByteString, Transport)
 uniqueRecv mk t = do
   mv <- newTVarIO IMap.empty
+  ev <- newEmptyTMVarIO
   void $
     forkIO $
     let w = do
@@ -50,17 +51,27 @@ uniqueRecv mk t = do
             Right buf -> do
               atomically $ modifyTVar' mv $ IMap.insert (mk buf) buf
               w
-            _ -> pure ()
+            Left err -> do
+              atomically $ putTMVar ev err
+              pure ()
      in w
   pure
-    ( \k ->
-        atomically $ do
-          m <- readTVar mv
-          case IMap.updateLookupWithKey (\_ _ -> Nothing) k m of
-            (Just r, m') -> do
-              writeTVar mv m'
-              pure r
-            _ -> retry
+    ( \k -> do
+        x <-
+          atomically $ do
+            m <- readTVar mv
+            case IMap.updateLookupWithKey (\_ _ -> Nothing) k m of
+              (Just r, m') -> do
+                writeTVar mv m'
+                pure $ Right r
+              _ -> do
+                me <- tryReadTMVar ev
+                case me of
+                  Just e -> pure $ Left e
+                  _ -> retry
+        case x of
+          Left e -> throwIO e
+          Right r -> pure r
     , t
         { recvData =
             fail

--- a/inline-js/tests/Tests/Echo.hs
+++ b/inline-js/tests/Tests/Echo.hs
@@ -32,7 +32,7 @@ tests =
                   ]
               , procStdErrInherit = True
               }
-        lockTransport $ strictTransport t)
+        lockSend $ strictTransport t)
     closeTransport
     (\gt ->
        testProperty "Echo via process transport" $


### PR DESCRIPTION
Changes:

* In the "process" transport, solved a bug in `recvData` which may return incomplete messages. Now it's fully strict and either returns the whole message or throws.
* `sendData` now pushes the message to a send queue and returns immediately, instead of holding a mutex.
* `recvData` is no longer susceptible to a race condition when a thread is blocked on `recvData`, but the expected message is received in another thread.