### PR TITLE
Generic Message class

### DIFF
--- a/inline-js-core/src/Language/JavaScript/Inline/Command.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Command.hs
@@ -14,11 +14,11 @@ import Language.JavaScript.Inline.Message.Eval
 import Language.JavaScript.Inline.Session
 import Prelude hiding (fail)
 
-checkRecvMsg :: RecvMsg -> IO LBS.ByteString
-checkRecvMsg Result {..} =
+checkEvalResponse :: EvalResponse -> IO LBS.ByteString
+checkEvalResponse EvalResponse {..} =
   if isError
     then fail $
-         "Language.JavaScript.Inline.Commands.checkRecvMsg: evaluation failed with " <>
+         "Language.JavaScript.Inline.Commands.checkEvalResponse: evaluation failed with " <>
          show result
     else pure result
 
@@ -26,13 +26,13 @@ eval :: JSSession -> JSCode -> IO LBS.ByteString
 eval s c =
   sendRecv
     s
-    Eval
+    EvalRequest
       { evalCode = c
       , evalTimeout = Nothing
       , resolveTimeout = Nothing
       , isAsync = False
       } >>=
-  checkRecvMsg
+  checkEvalResponse
 
 evalTo :: (LBS.ByteString -> Either String a) -> JSSession -> JSCode -> IO a
 evalTo p s c = do
@@ -45,13 +45,13 @@ evalAsync :: JSSession -> JSCode -> IO LBS.ByteString
 evalAsync s c =
   sendRecv
     s
-    Eval
+    EvalRequest
       { evalCode = c
       , evalTimeout = Nothing
       , resolveTimeout = Nothing
       , isAsync = True
       } >>=
-  checkRecvMsg
+  checkEvalResponse
 
 evalAsyncTo ::
      (LBS.ByteString -> Either String a) -> JSSession -> JSCode -> IO a

--- a/inline-js-core/src/Language/JavaScript/Inline/Command.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Command.hs
@@ -10,7 +10,7 @@ module Language.JavaScript.Inline.Command
 import Control.Monad.Fail
 import qualified Data.ByteString.Lazy as LBS
 import Language.JavaScript.Inline.JSCode
-import Language.JavaScript.Inline.Message
+import Language.JavaScript.Inline.Message.Eval
 import Language.JavaScript.Inline.Session
 import Prelude hiding (fail)
 

--- a/inline-js-core/src/Language/JavaScript/Inline/Message/Class.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Message/Class.hs
@@ -1,0 +1,37 @@
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+
+module Language.JavaScript.Inline.Message.Class
+  ( Message(..)
+  , encodeRequest
+  , decodeResponse
+  ) where
+
+import Data.Binary.Get
+import Data.Binary.Put
+import qualified Data.ByteString.Lazy as LBS
+import Language.JavaScript.Inline.MessageCounter
+
+class Message i o | i -> o, o -> i where
+  putRequest :: i -> Put
+  getResponse :: Get o
+
+encodeRequest :: Message i o => MsgId -> i -> LBS.ByteString
+encodeRequest msg_id req =
+  runPut $ do
+    putWord32host $ fromIntegral msg_id
+    putRequest req
+
+decodeResponse :: Message i o => MsgId -> LBS.ByteString -> IO o
+decodeResponse msg_id buf =
+  case runGetOrFail
+         ((,) <$> (fromIntegral <$> getWord32host) <*> getResponse)
+         buf of
+    Right (rest, _, (msg_id', resp))
+      | LBS.null rest && msg_id == msg_id' -> pure resp
+    _ ->
+      fail $
+      "Language.JavaScript.Inline.Message.Class.decodeResponse: failed to decode message " <>
+      show msg_id <>
+      " from " <>
+      show buf

--- a/inline-js-core/src/Language/JavaScript/Inline/Message/Eval.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Message/Eval.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE StrictData #-}
 
-module Language.JavaScript.Inline.Message
+module Language.JavaScript.Inline.Message.Eval
   ( SendMsg(..)
   , encodeSendMsg
   , RecvMsg(..)

--- a/inline-js-core/src/Language/JavaScript/Inline/Message/Eval.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Message/Eval.hs
@@ -1,11 +1,10 @@
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE StrictData #-}
 
 module Language.JavaScript.Inline.Message.Eval
   ( EvalRequest(..)
-  , encodeEvalRequest
   , EvalResponse(..)
-  , decodeEvalResponse
   ) where
 
 import Data.Binary.Get
@@ -13,7 +12,7 @@ import Data.Binary.Put
 import qualified Data.ByteString.Lazy as LBS
 import Data.Coerce
 import qualified Language.JavaScript.Inline.JSCode as JSCode
-import Language.JavaScript.Inline.MessageCounter
+import Language.JavaScript.Inline.Message.Class
 
 data EvalRequest = EvalRequest
   { isAsync :: Bool
@@ -21,42 +20,29 @@ data EvalRequest = EvalRequest
   , evalCode :: JSCode.JSCode
   }
 
-encodeEvalRequest :: MsgId -> EvalRequest -> LBS.ByteString
-encodeEvalRequest msg_id msg = runPut $ putEvalRequest msg_id msg
-
 data EvalResponse = EvalResponse
   { isError :: Bool
   , result :: LBS.ByteString
   }
 
-decodeEvalResponse :: LBS.ByteString -> Either String (MsgId, EvalResponse)
-decodeEvalResponse buf =
-  case runGetOrFail getEvalResponse buf of
-    Left err -> Left $ show err
-    Right (_, _, r) -> Right r
-
-putEvalRequest :: MsgId -> EvalRequest -> Put
-putEvalRequest msg_id EvalRequest {..} = do
-  putWord32le $ fromIntegral msg_id
-  putWord32le $
-    if isAsync
-      then 1
-      else 0
-  putWord32le $
-    fromIntegral $
-    case evalTimeout of
-      Just t -> t
-      _ -> 0
-  putWord32le $
-    fromIntegral $
-    case resolveTimeout of
-      Just t -> t
-      _ -> 0
-  putBuilder $ coerce evalCode
-
-getEvalResponse :: Get (MsgId, EvalResponse)
-getEvalResponse = do
-  msg_id <- getWord32le
-  is_err <- getWord32le
-  r <- getRemainingLazyByteString
-  pure (fromIntegral msg_id, EvalResponse {isError = is_err /= 0, result = r})
+instance Message EvalRequest EvalResponse where
+  putRequest EvalRequest {..} = do
+    putWord32host $
+      if isAsync
+        then 1
+        else 0
+    putWord32host $
+      fromIntegral $
+      case evalTimeout of
+        Just t -> t
+        _ -> 0
+    putWord32host $
+      fromIntegral $
+      case resolveTimeout of
+        Just t -> t
+        _ -> 0
+    putBuilder $ coerce evalCode
+  getResponse = do
+    is_err <- getWord32host
+    r <- getRemainingLazyByteString
+    pure EvalResponse {isError = is_err /= 0, result = r}

--- a/inline-js-core/src/Language/JavaScript/Inline/Session.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Session.hs
@@ -75,21 +75,21 @@ closeJSSession JSSession {..} = closeTransport nodeTransport
 withJSSession :: JSSessionOpts -> (JSSession -> IO r) -> IO r
 withJSSession opts = bracket (newJSSession opts) closeJSSession
 
-sendMsg :: JSSession -> SendMsg -> IO MsgId
+sendMsg :: JSSession -> EvalRequest -> IO MsgId
 sendMsg JSSession {..} msg = do
   msg_id <- newMsgId msgCounter
-  sendData nodeTransport $ encodeSendMsg msg_id msg
+  sendData nodeTransport $ encodeEvalRequest msg_id msg
   pure msg_id
 
-recvMsg :: JSSession -> MsgId -> IO RecvMsg
+recvMsg :: JSSession -> MsgId -> IO EvalResponse
 recvMsg JSSession {..} msg_id = do
   buf <- msgRecv msg_id
-  case decodeRecvMsg buf of
+  case decodeEvalResponse buf of
     Left err ->
       fail $
-      "Language.JavaScript.Inline.Session.recvMsg: parsing RecvMsg failed with " <>
+      "Language.JavaScript.Inline.Session.recvMsg: parsing EvalResponse failed with " <>
       err
     Right (_, msg) -> pure msg
 
-sendRecv :: JSSession -> SendMsg -> IO RecvMsg
+sendRecv :: JSSession -> EvalRequest -> IO EvalResponse
 sendRecv s = recvMsg s <=< sendMsg s

--- a/inline-js-core/src/Language/JavaScript/Inline/Session.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Session.hs
@@ -19,7 +19,7 @@ import Control.Monad
 import Data.Binary.Get
 import qualified Data.ByteString.Lazy as LBS
 import Data.Coerce
-import Language.JavaScript.Inline.Message
+import Language.JavaScript.Inline.Message.Eval
 import Language.JavaScript.Inline.MessageCounter
 import Language.JavaScript.Inline.Transport.Process
 import Language.JavaScript.Inline.Transport.Type

--- a/inline-js/tests/Tests/Evaluation.hs
+++ b/inline-js/tests/Tests/Evaluation.hs
@@ -7,7 +7,7 @@ module Tests.Evaluation
 
 import Data.Aeson
 import Data.Foldable
-import Language.JavaScript.Inline.Message
+import Language.JavaScript.Inline.Message.Eval
 import Language.JavaScript.Inline.Session
 import Test.Tasty (TestTree)
 import Test.Tasty.Hspec (it, shouldBe, testSpec)

--- a/inline-js/tests/Tests/Evaluation.hs
+++ b/inline-js/tests/Tests/Evaluation.hs
@@ -28,7 +28,7 @@ tests =
       traverse
         requestTest
         [ ( asyncEvaluation "import('fs')"
-          , \Result {isError} -> isError `shouldBe` False)
+          , \EvalResponse {isError} -> isError `shouldBe` False)
         , (syncEvaluation "while(true){}" `withEvalTimeout` 1000, failsToReturn)
         , (syncEvaluation "BOOM", failsToReturn)
         , (syncEvaluation "undefined", successfullyReturns Null)
@@ -46,10 +46,10 @@ tests =
         ]
     traverse_ recvAndRunTest testPairs
 
-failsToReturn :: RecvMsg -> IO ()
-failsToReturn Result {isError} = isError `shouldBe` True
+failsToReturn :: EvalResponse -> IO ()
+failsToReturn EvalResponse {isError} = isError `shouldBe` True
 
-successfullyReturns :: Value -> RecvMsg -> IO ()
-successfullyReturns expected Result {isError, result} = do
+successfullyReturns :: Value -> EvalResponse -> IO ()
+successfullyReturns expected EvalResponse {isError, result} = do
   isError `shouldBe` False
   decode' result `shouldBe` Just expected

--- a/inline-js/tests/Tests/Helpers/Message.hs
+++ b/inline-js/tests/Tests/Helpers/Message.hs
@@ -6,7 +6,7 @@ module Tests.Helpers.Message
   ) where
 
 import Language.JavaScript.Inline.JSCode
-import Language.JavaScript.Inline.Message
+import Language.JavaScript.Inline.Message.Eval
 
 syncEvaluation :: JSCode -> SendMsg
 syncEvaluation = Eval False Nothing Nothing

--- a/inline-js/tests/Tests/Helpers/Message.hs
+++ b/inline-js/tests/Tests/Helpers/Message.hs
@@ -8,15 +8,15 @@ module Tests.Helpers.Message
 import Language.JavaScript.Inline.JSCode
 import Language.JavaScript.Inline.Message.Eval
 
-syncEvaluation :: JSCode -> SendMsg
-syncEvaluation = Eval False Nothing Nothing
+syncEvaluation :: JSCode -> EvalRequest
+syncEvaluation = EvalRequest False Nothing Nothing
 
-asyncEvaluation :: JSCode -> SendMsg
-asyncEvaluation = Eval True Nothing Nothing
+asyncEvaluation :: JSCode -> EvalRequest
+asyncEvaluation = EvalRequest True Nothing Nothing
 
-withEvalTimeout :: SendMsg -> Int -> SendMsg
+withEvalTimeout :: EvalRequest -> Int -> EvalRequest
 withEvalTimeout request milliseconds = request {evalTimeout = pure milliseconds}
 
-withResolveTimeout :: SendMsg -> Int -> SendMsg
+withResolveTimeout :: EvalRequest -> Int -> EvalRequest
 withResolveTimeout request milliseconds =
   request {resolveTimeout = pure milliseconds}


### PR DESCRIPTION
We used to only support a single kind of messages: eval requests/responses. This PR adds a `Message` class, and make the `send`/`recv` functions in `Language.JavaScript.Inline.Session` operate on generic messages. This makes it easy to extend the node eval server with new message handlers.