### PR TITLE
Direct support of binary data marshaling

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
       - run:
           name: Install dependencies
           command: |
-            nix-channel --add https://releases.nixos.org/nixpkgs/nixpkgs-19.09pre173445.796a8764ab8 nixpkgs
+            nix-channel --add https://releases.nixos.org/nixpkgs/nixpkgs-19.09pre173720.d73f16d6767 nixpkgs
             nix-channel --update
             nix-env -u
             nix-env -iA \
@@ -20,7 +20,7 @@ jobs:
               nixpkgs.stack
       - checkout
       - run:
-          name: Test inline-js and inline-js-core
+          name: Test inline-js
           command: |
-            stack --no-terminal build inline-js-core inline-js --test --no-run-tests
-            stack --no-terminal test inline-js
+            stack --nix --no-terminal build --test --no-run-tests
+            stack --nix --no-terminal test inline-js

--- a/inline-js-core/jsbits/eval.mjs
+++ b/inline-js-core/jsbits/eval.mjs
@@ -10,11 +10,11 @@ process.on("uncaughtException", err => {
 
 const __jsrefs = [];
 
-global.JSRef = class {
-  static newJSRef(v) {
+global.JSVal = class {
+  static newJSVal(v) {
     return __jsrefs.push(v) - 1;
   }
-  static deRefJSRef(p) {
+  static deRefJSVal(p) {
     return __jsrefs[p];
   }
 };

--- a/inline-js-core/jsbits/eval.mjs
+++ b/inline-js-core/jsbits/eval.mjs
@@ -8,7 +8,7 @@ process.on("uncaughtException", err => {
   throw err;
 });
 
-const __jsrefs = [];
+const __jsrefs = [undefined];
 
 global.JSVal = class {
   static newJSVal(v) {

--- a/inline-js-core/jsbits/eval.mjs
+++ b/inline-js-core/jsbits/eval.mjs
@@ -66,5 +66,3 @@ ipc.on("recv", async buf => {
     sendMsg(msg_id, true, err.toString());
   }
 });
-
-sendMsg(0, false, null);

--- a/inline-js-core/jsbits/eval.mjs
+++ b/inline-js-core/jsbits/eval.mjs
@@ -12,10 +12,10 @@ const __jsrefs = [undefined];
 
 global.JSVal = class {
   static newJSVal(v) {
-    return __jsrefs.push(v) - 1;
+    return v === undefined || v === null ? 0 : __jsrefs.push(v) - 1;
   }
   static deRefJSVal(p) {
-    return __jsrefs[p];
+    return p ? __jsrefs[p] : null;
   }
 };
 
@@ -25,7 +25,6 @@ const ipc = new Transport(process.stdin, process.stdout);
 
 function sendMsg(msg_id, ret_tag, is_err, result) {
   try {
-    if (result === undefined) result = null;
     switch (ret_tag) {
       case 0: {
         const result_buf = Buffer.from(result),
@@ -40,7 +39,7 @@ function sendMsg(msg_id, ret_tag, is_err, result) {
         const msg_buf = Buffer.allocUnsafe(12);
         msg_buf.writeUInt32LE(msg_id, 0);
         msg_buf.writeUInt32LE(0, 4);
-        msg_buf.writeUInt32LE(result, 8);
+        msg_buf.writeUInt32LE(JSVal.newJSVal(result), 8);
         ipc.send(msg_buf);
         break;
       }

--- a/inline-js-core/jsbits/eval.mjs
+++ b/inline-js-core/jsbits/eval.mjs
@@ -28,7 +28,7 @@ function sendMsg(msg_id, ret_tag, is_err, result) {
     if (result === undefined) result = null;
     switch (ret_tag) {
       case 0: {
-        const result_buf = Buffer.from(JSON.stringify(result)),
+        const result_buf = Buffer.from(result),
           msg_buf = Buffer.allocUnsafe(8 + result_buf.length);
         msg_buf.writeUInt32LE(msg_id, 0);
         msg_buf.writeUInt32LE(Number(is_err), 4);

--- a/inline-js-core/jsbits/eval.mjs
+++ b/inline-js-core/jsbits/eval.mjs
@@ -19,7 +19,7 @@ global.JSVal = class {
   }
 };
 
-const ctx = vm.createContext(Object.assign({}, global));
+const ctx = vm.createContext(global);
 
 const ipc = new Transport(process.stdin, process.stdout);
 
@@ -85,6 +85,10 @@ ipc.on("recv", async buf => {
         } else {
           sendMsg(msg_id, ret_tag, false, eval_result);
         }
+        break;
+      }
+      case 1: {
+        sendMsg(msg_id, 1, false, buf.slice(8));
         break;
       }
       default: {

--- a/inline-js-core/src/Language/JavaScript/Inline/Command.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Command.hs
@@ -5,9 +5,11 @@
 module Language.JavaScript.Inline.Command
   ( eval
   , evalAsync
+  , alloc
   ) where
 
 import Control.Monad.Fail
+import qualified Data.ByteString.Lazy as LBS
 import Language.JavaScript.Inline.JSCode
 import Language.JavaScript.Inline.Message.Class
 import Language.JavaScript.Inline.Message.Eval
@@ -54,3 +56,6 @@ evalAsync s c =
        , isAsync = True
        } :: EvalRequest r) >>=
   checkEvalResponse
+
+alloc :: JSSession -> LBS.ByteString -> IO JSVal
+alloc s buf = sendRecv s AllocRequest {allocContent = buf} >>= checkEvalResponse

--- a/inline-js-core/src/Language/JavaScript/Inline/Command.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Command.hs
@@ -15,12 +15,13 @@ import Language.JavaScript.Inline.Session
 import Prelude hiding (fail)
 
 checkEvalResponse :: EvalResponse -> IO LBS.ByteString
-checkEvalResponse EvalResponse {..} =
-  if isError
-    then fail $
-         "Language.JavaScript.Inline.Commands.checkEvalResponse: evaluation failed with " <>
-         show result
-    else pure result
+checkEvalResponse r =
+  case r of
+    EvalError {..} ->
+      fail $
+      "Language.JavaScript.Inline.Commands.checkEvalResponse: evaluation failed with " <>
+      show evalError
+    EvalResult {..} -> pure evalResult
 
 eval :: JSSession -> JSCode -> IO LBS.ByteString
 eval s c =

--- a/inline-js-core/src/Language/JavaScript/Inline/Command.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Command.hs
@@ -14,7 +14,7 @@ import Language.JavaScript.Inline.Message.Eval
 import Language.JavaScript.Inline.Session
 import Prelude hiding (fail)
 
-checkEvalResponse :: EvalResponse -> IO LBS.ByteString
+checkEvalResponse :: EvalResponse LBS.ByteString -> IO LBS.ByteString
 checkEvalResponse r =
   case r of
     EvalError {..} ->

--- a/inline-js-core/src/Language/JavaScript/Inline/JSCode.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/JSCode.hs
@@ -5,10 +5,10 @@ module Language.JavaScript.Inline.JSCode
   , codeToString
   , codeFromString
   , codeFromValueLBS
-  , JSRef
-  , parseJSRef
-  , newJSRef
-  , deRefJSRef
+  , JSVal
+  , parseJSVal
+  , newJSVal
+  , deRefJSVal
   ) where
 
 import Data.ByteString.Builder
@@ -36,20 +36,20 @@ codeFromValueLBS buf =
   JSCode $
   mconcat [fromString "JSON.parse(", lazyByteString buf, fromString ")"]
 
-newtype JSRef =
-  JSRef Int
+newtype JSVal =
+  JSVal Int
   deriving (Eq, Ord, Show)
 
-parseJSRef :: LBS.ByteString -> Either String JSRef
-parseJSRef buf =
+parseJSVal :: LBS.ByteString -> Either String JSVal
+parseJSVal buf =
   case Text.decimal $ Text.decodeUtf8 $ LBS.toStrict buf of
-    Right (r, _) -> Right $ JSRef r
-    _ -> Left "Language.JavaScript.Inline.JSCode.parseJSRef"
+    Right (r, _) -> Right $ JSVal r
+    _ -> Left "Language.JavaScript.Inline.JSCode.parseJSVal"
 
-newJSRef :: JSCode -> JSCode
-newJSRef expr =
-  JSCode $ mconcat [fromString "JSRef.newJSRef((", unwrap expr, fromString "))"]
+newJSVal :: JSCode -> JSCode
+newJSVal expr =
+  JSCode $ mconcat [fromString "JSVal.newJSVal((", unwrap expr, fromString "))"]
 
-deRefJSRef :: JSRef -> JSCode
-deRefJSRef (JSRef p) =
-  JSCode $ mconcat [fromString "JSRef.deRefJSRef(", intDec p, fromString ")"]
+deRefJSVal :: JSVal -> JSCode
+deRefJSVal (JSVal p) =
+  JSCode $ mconcat [fromString "JSVal.deRefJSVal(", intDec p, fromString ")"]

--- a/inline-js-core/src/Language/JavaScript/Inline/JSCode.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/JSCode.hs
@@ -5,7 +5,8 @@ module Language.JavaScript.Inline.JSCode
   ( JSCode(..)
   , codeToString
   , codeFromString
-  , codeFromValueLBS
+  , bufferToString
+  , jsonParse
   , jsonStringify
   , JSVal(..)
   , deRefJSVal
@@ -30,12 +31,12 @@ codeFromString = JSCode . byteString . Text.encodeUtf8
 codeToString :: JSCode -> Text
 codeToString = Text.decodeUtf8 . LBS.toStrict . toLazyByteString . unwrap
 
-codeFromValueLBS :: LBS.ByteString -> JSCode
-codeFromValueLBS buf =
-  JSCode $
-  mconcat [fromString "JSON.parse(", lazyByteString buf, fromString ")"]
+bufferToString, jsonParse, jsonStringify :: JSCode -> JSCode
+bufferToString expr =
+  "(new TextDecoder('utf-8', {fatal: true})).decode(" <> expr <> ")"
 
-jsonStringify :: JSCode -> JSCode
+jsonParse expr = "JSON.parse(" <> expr <> ")"
+
 jsonStringify expr = "JSON.stringify(" <> expr <> ")"
 
 newtype JSVal =

--- a/inline-js-core/src/Language/JavaScript/Inline/JSCode.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/JSCode.hs
@@ -5,7 +5,7 @@ module Language.JavaScript.Inline.JSCode
   , codeToString
   , codeFromString
   , codeFromValueLBS
-  , JSVal
+  , JSVal(..)
   , parseJSVal
   , newJSVal
   , deRefJSVal

--- a/inline-js-core/src/Language/JavaScript/Inline/JSCode.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/JSCode.hs
@@ -1,10 +1,12 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 module Language.JavaScript.Inline.JSCode
   ( JSCode(..)
   , codeToString
   , codeFromString
   , codeFromValueLBS
+  , jsonStringify
   , JSVal(..)
   , newJSVal
   , deRefJSVal
@@ -18,7 +20,7 @@ import qualified Data.Text.Encoding as Text
 
 newtype JSCode =
   JSCode Builder
-  deriving (IsString)
+  deriving (IsString, Semigroup)
 
 unwrap :: JSCode -> Builder
 unwrap (JSCode builder) = builder
@@ -33,6 +35,9 @@ codeFromValueLBS :: LBS.ByteString -> JSCode
 codeFromValueLBS buf =
   JSCode $
   mconcat [fromString "JSON.parse(", lazyByteString buf, fromString ")"]
+
+jsonStringify :: JSCode -> JSCode
+jsonStringify expr = "JSON.stringify(" <> expr <> ")"
 
 newtype JSVal =
   JSVal Int

--- a/inline-js-core/src/Language/JavaScript/Inline/JSCode.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/JSCode.hs
@@ -6,7 +6,6 @@ module Language.JavaScript.Inline.JSCode
   , codeFromString
   , codeFromValueLBS
   , JSVal(..)
-  , parseJSVal
   , newJSVal
   , deRefJSVal
   ) where
@@ -16,7 +15,6 @@ import qualified Data.ByteString.Lazy as LBS
 import Data.String (IsString(..))
 import Data.Text (Text)
 import qualified Data.Text.Encoding as Text
-import qualified Data.Text.Read as Text
 
 newtype JSCode =
   JSCode Builder
@@ -39,12 +37,6 @@ codeFromValueLBS buf =
 newtype JSVal =
   JSVal Int
   deriving (Eq, Ord, Show)
-
-parseJSVal :: LBS.ByteString -> Either String JSVal
-parseJSVal buf =
-  case Text.decimal $ Text.decodeUtf8 $ LBS.toStrict buf of
-    Right (r, _) -> Right $ JSVal r
-    _ -> Left "Language.JavaScript.Inline.JSCode.parseJSVal"
 
 newJSVal :: JSCode -> JSCode
 newJSVal expr =

--- a/inline-js-core/src/Language/JavaScript/Inline/JSCode.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/JSCode.hs
@@ -8,7 +8,6 @@ module Language.JavaScript.Inline.JSCode
   , codeFromValueLBS
   , jsonStringify
   , JSVal(..)
-  , newJSVal
   , deRefJSVal
   ) where
 
@@ -42,10 +41,6 @@ jsonStringify expr = "JSON.stringify(" <> expr <> ")"
 newtype JSVal =
   JSVal Int
   deriving (Eq, Ord, Show)
-
-newJSVal :: JSCode -> JSCode
-newJSVal expr =
-  JSCode $ mconcat [fromString "JSVal.newJSVal((", unwrap expr, fromString "))"]
 
 deRefJSVal :: JSVal -> JSCode
 deRefJSVal (JSVal p) =

--- a/inline-js-core/src/Language/JavaScript/Inline/Message/Eval.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Message/Eval.hs
@@ -20,10 +20,9 @@ data EvalRequest = EvalRequest
   , evalCode :: JSCode.JSCode
   }
 
-data EvalResponse = EvalResponse
-  { isError :: Bool
-  , result :: LBS.ByteString
-  }
+data EvalResponse
+  = EvalError { evalError :: LBS.ByteString }
+  | EvalResult { evalResult :: LBS.ByteString }
 
 instance Message EvalRequest EvalResponse where
   putRequest EvalRequest {..} = do
@@ -46,4 +45,7 @@ instance Message EvalRequest EvalResponse where
   getResponse = do
     is_err <- getWord32host
     r <- getRemainingLazyByteString
-    pure EvalResponse {isError = is_err /= 0, result = r}
+    pure $
+      case is_err of
+        0 -> EvalResult {evalResult = r}
+        _ -> EvalError {evalError = r}

--- a/inline-js-core/src/Language/JavaScript/Inline/Message/Eval.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Message/Eval.hs
@@ -24,7 +24,7 @@ data EvalResponse
   = EvalError { evalError :: LBS.ByteString }
   | EvalResult { evalResult :: LBS.ByteString }
 
-instance Message EvalRequest EvalResponse where
+instance Request EvalRequest where
   putRequest EvalRequest {..} = do
     putWord32host 0
     putWord32host $
@@ -42,6 +42,8 @@ instance Message EvalRequest EvalResponse where
         Just t -> t
         _ -> 0
     putBuilder $ coerce evalCode
+
+instance Response EvalResponse where
   getResponse = do
     is_err <- getWord32host
     r <- getRemainingLazyByteString

--- a/inline-js-core/src/Language/JavaScript/Inline/Message/Eval.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Message/Eval.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE StrictData #-}
@@ -20,9 +21,9 @@ data EvalRequest = EvalRequest
   , evalCode :: JSCode.JSCode
   }
 
-data EvalResponse
+data EvalResponse a
   = EvalError { evalError :: LBS.ByteString }
-  | EvalResult { evalResult :: LBS.ByteString }
+  | EvalResult { evalResult :: a }
 
 instance Request EvalRequest where
   putRequest EvalRequest {..} = do
@@ -43,7 +44,7 @@ instance Request EvalRequest where
         _ -> 0
     putBuilder $ coerce evalCode
 
-instance Response EvalResponse where
+instance Response (EvalResponse LBS.ByteString) where
   getResponse = do
     is_err <- getWord32host
     r <- getRemainingLazyByteString

--- a/inline-js-core/src/Language/JavaScript/Inline/Message/Eval.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Message/Eval.hs
@@ -15,7 +15,7 @@ import Data.Coerce
 import qualified Language.JavaScript.Inline.JSCode as JSCode
 import Language.JavaScript.Inline.Message.Class
 
-data EvalRequest = EvalRequest
+data EvalRequest a = EvalRequest
   { isAsync :: Bool
   , evalTimeout, resolveTimeout :: Maybe Int
   , evalCode :: JSCode.JSCode
@@ -25,7 +25,7 @@ data EvalResponse a
   = EvalError { evalError :: LBS.ByteString }
   | EvalResult { evalResult :: a }
 
-instance Request EvalRequest where
+instance Request (EvalRequest a) where
   putRequest EvalRequest {..} = do
     putWord32host 0
     putWord32host $

--- a/inline-js-core/src/Language/JavaScript/Inline/Message/Eval.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Message/Eval.hs
@@ -27,6 +27,7 @@ data EvalResponse = EvalResponse
 
 instance Message EvalRequest EvalResponse where
   putRequest EvalRequest {..} = do
+    putWord32host 0
     putWord32host $
       if isAsync
         then 1

--- a/inline-js-core/src/Language/JavaScript/Inline/Message/Eval.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Message/Eval.hs
@@ -12,6 +12,7 @@ import Data.Binary.Get
 import Data.Binary.Put
 import qualified Data.ByteString.Lazy as LBS
 import Data.Coerce
+import Data.Word
 import qualified Language.JavaScript.Inline.JSCode as JSCode
 import Language.JavaScript.Inline.Message.Class
 
@@ -25,30 +26,37 @@ data EvalResponse a
   = EvalError { evalError :: LBS.ByteString }
   | EvalResult { evalResult :: a }
 
-instance Request (EvalRequest a) where
-  putRequest EvalRequest {..} = do
-    putWord32host 0
-    putWord32host $
-      if isAsync
-        then 1
-        else 0
-    putWord32host $
-      fromIntegral $
-      case evalTimeout of
-        Just t -> t
-        _ -> 0
-    putWord32host $
-      fromIntegral $
-      case resolveTimeout of
-        Just t -> t
-        _ -> 0
-    putBuilder $ coerce evalCode
+instance Request (EvalRequest LBS.ByteString) where
+  putRequest = putRequestWith 0
+
+instance Request (EvalRequest JSCode.JSVal) where
+  putRequest = putRequestWith 1
 
 instance Response (EvalResponse LBS.ByteString) where
   getResponse = getResponseWith getRemainingLazyByteString
 
 instance Response (EvalResponse JSCode.JSVal) where
   getResponse = getResponseWith (JSCode.JSVal . fromIntegral <$> getWord32host)
+
+putRequestWith :: Word32 -> EvalRequest a -> Put
+putRequestWith rt EvalRequest {..} = do
+  putWord32host 0
+  putWord32host rt
+  putWord32host $
+    if isAsync
+      then 1
+      else 0
+  putWord32host $
+    fromIntegral $
+    case evalTimeout of
+      Just t -> t
+      _ -> 0
+  putWord32host $
+    fromIntegral $
+    case resolveTimeout of
+      Just t -> t
+      _ -> 0
+  putBuilder $ coerce evalCode
 
 getResponseWith :: Get r -> Get (EvalResponse r)
 getResponseWith p = do

--- a/inline-js-core/src/Language/JavaScript/Inline/Session.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Session.hs
@@ -75,16 +75,16 @@ closeJSSession JSSession {..} = closeTransport nodeTransport
 withJSSession :: JSSessionOpts -> (JSSession -> IO r) -> IO r
 withJSSession opts = bracket (newJSSession opts) closeJSSession
 
-sendMsg :: Message i o => JSSession -> i -> IO MsgId
+sendMsg :: Request r => JSSession -> r -> IO MsgId
 sendMsg JSSession {..} msg = do
   msg_id <- newMsgId msgCounter
   sendData nodeTransport $ encodeRequest msg_id msg
   pure msg_id
 
-recvMsg :: Message i o => JSSession -> MsgId -> IO o
+recvMsg :: Response r => JSSession -> MsgId -> IO r
 recvMsg JSSession {..} msg_id = do
   buf <- msgRecv msg_id
   decodeResponse msg_id buf
 
-sendRecv :: Message i o => JSSession -> i -> IO o
+sendRecv :: (Request req, Response resp) => JSSession -> req -> IO resp
 sendRecv s = recvMsg s <=< sendMsg s

--- a/inline-js/src/Language/JavaScript/Inline.hs
+++ b/inline-js/src/Language/JavaScript/Inline.hs
@@ -45,7 +45,7 @@ block = qq blockQuasiQuoter
 
 --- produces splice with type `JSSession -> IO JSCode`
 expressionQuasiQuoter :: String -> Q TH.Exp
-expressionQuasiQuoter input = blockQuasiQuoter $ "return " ++ input ++ ";"
+expressionQuasiQuoter input = blockQuasiQuoter $ "return " <> input <> ";"
 
 --- produces splice with type `JSSession -> IO JSCode`
 blockQuasiQuoter :: String -> Q TH.Exp
@@ -72,13 +72,13 @@ blockQuasiQuoter input =
 wrapCode :: String -> [String] -> Q TH.Exp
 wrapCode code antiquotedNames =
   [|mconcat
-      [ pack "(function( "
+      [ pack "JSON.stringify((function( "
       , $(argumentList antiquotedNames)
       , pack " ) { "
       , pack code
       , pack " })( "
       , $(argumentValues antiquotedNames)
-      , pack " );"
+      , pack " ))"
       ]|]
 
 argumentList :: [String] -> Q TH.Exp

--- a/inline-js/tests/Tests/Evaluation.hs
+++ b/inline-js/tests/Tests/Evaluation.hs
@@ -35,16 +35,18 @@ tests =
     testPairs <-
       traverse
         requestTest
-        [ (asyncEvaluation "import('fs')", \r -> isError r `shouldBe` False)
+        [ ( asyncEvaluation
+              "import('fs').then(fs => fs.readFileSync.toString())"
+          , \r -> isError r `shouldBe` False)
         , (syncEvaluation "while(true){}" `withEvalTimeout` 1000, failsToReturn)
         , (syncEvaluation "BOOM", failsToReturn)
-        , (syncEvaluation "undefined", successfullyReturns Null)
-        , (syncEvaluation "let x = 6*7", successfullyReturns Null)
-        , (syncEvaluation "x", successfullyReturns $ Number 42)
-        , ( syncEvaluation "\"left\" + \"pad\""
+        , ( syncEvaluation "let x = 6*7; JSON.stringify(null)"
+          , successfullyReturns Null)
+        , (syncEvaluation "JSON.stringify(x)", successfullyReturns $ Number 42)
+        , ( syncEvaluation "JSON.stringify(\"left\" + \"pad\")"
           , successfullyReturns $ String "leftpad")
         , (asyncEvaluation "Promise.reject('BOOM')", failsToReturn)
-        , ( asyncEvaluation "Promise.resolve(x)"
+        , ( asyncEvaluation "Promise.resolve(JSON.stringify(x))"
           , successfullyReturns $ Number 42)
         , ( asyncEvaluation
               "new Promise((resolve, _) => setTimeout(resolve, 10000))" `withResolveTimeout`

--- a/inline-js/tests/Tests/Evaluation.hs
+++ b/inline-js/tests/Tests/Evaluation.hs
@@ -27,8 +27,7 @@ tests =
     testPairs <-
       traverse
         requestTest
-        [ ( asyncEvaluation "import('fs')"
-          , \EvalResponse {isError} -> isError `shouldBe` False)
+        [ (asyncEvaluation "import('fs')", \r -> isError r `shouldBe` False)
         , (syncEvaluation "while(true){}" `withEvalTimeout` 1000, failsToReturn)
         , (syncEvaluation "BOOM", failsToReturn)
         , (syncEvaluation "undefined", successfullyReturns Null)
@@ -47,9 +46,13 @@ tests =
     traverse_ recvAndRunTest testPairs
 
 failsToReturn :: EvalResponse -> IO ()
-failsToReturn EvalResponse {isError} = isError `shouldBe` True
+failsToReturn r = isError r `shouldBe` True
 
 successfullyReturns :: Value -> EvalResponse -> IO ()
-successfullyReturns expected EvalResponse {isError, result} = do
-  isError `shouldBe` False
-  decode' result `shouldBe` Just expected
+successfullyReturns expected r = do
+  isError r `shouldBe` False
+  decode' (evalResult r) `shouldBe` Just expected
+
+isError :: EvalResponse -> Bool
+isError EvalError {} = True
+isError _ = False

--- a/inline-js/tests/Tests/Evaluation.hs
+++ b/inline-js/tests/Tests/Evaluation.hs
@@ -6,6 +6,7 @@ module Tests.Evaluation
   ) where
 
 import Data.Aeson
+import qualified Data.ByteString.Lazy as LBS
 import Data.Foldable
 import Language.JavaScript.Inline.Message.Eval
 import Language.JavaScript.Inline.Session
@@ -45,14 +46,14 @@ tests =
         ]
     traverse_ recvAndRunTest testPairs
 
-failsToReturn :: EvalResponse -> IO ()
+failsToReturn :: EvalResponse LBS.ByteString -> IO ()
 failsToReturn r = isError r `shouldBe` True
 
-successfullyReturns :: Value -> EvalResponse -> IO ()
+successfullyReturns :: Value -> EvalResponse LBS.ByteString -> IO ()
 successfullyReturns expected r = do
   isError r `shouldBe` False
   decode' (evalResult r) `shouldBe` Just expected
 
-isError :: EvalResponse -> Bool
+isError :: EvalResponse LBS.ByteString -> Bool
 isError EvalError {} = True
 isError _ = False

--- a/inline-js/tests/Tests/Helpers/Message.hs
+++ b/inline-js/tests/Tests/Helpers/Message.hs
@@ -8,15 +8,15 @@ module Tests.Helpers.Message
 import Language.JavaScript.Inline.JSCode
 import Language.JavaScript.Inline.Message.Eval
 
-syncEvaluation :: JSCode -> EvalRequest
+syncEvaluation :: JSCode -> EvalRequest a
 syncEvaluation = EvalRequest False Nothing Nothing
 
-asyncEvaluation :: JSCode -> EvalRequest
+asyncEvaluation :: JSCode -> EvalRequest a
 asyncEvaluation = EvalRequest True Nothing Nothing
 
-withEvalTimeout :: EvalRequest -> Int -> EvalRequest
+withEvalTimeout :: EvalRequest a -> Int -> EvalRequest a
 withEvalTimeout request milliseconds = request {evalTimeout = pure milliseconds}
 
-withResolveTimeout :: EvalRequest -> Int -> EvalRequest
+withResolveTimeout :: EvalRequest a -> Int -> EvalRequest a
 withResolveTimeout request milliseconds =
   request {resolveTimeout = pure milliseconds}

--- a/inline-js/tests/Tests/PingPong.hs
+++ b/inline-js/tests/Tests/PingPong.hs
@@ -58,7 +58,8 @@ tests =
             newJSVal $
             codeFromValueLBS $
             encode $ String $ Text.decodeUtf8 $ LBS.toStrict $ encode v
-          _recv_v <- fmap (fromJust . decode') $ eval s $ deRefJSVal p
+          _recv_v <-
+            fmap (fromJust . decode') $ eval s $ jsonStringify $ deRefJSVal p
           unless (v == _recv_v) $
             fail $ "pingpong: pong mismatch: " <> show (v, _recv_v)
 

--- a/inline-js/tests/Tests/PingPong.hs
+++ b/inline-js/tests/Tests/PingPong.hs
@@ -54,7 +54,7 @@ tests =
       forAllM genValue $ \v ->
         run $ do
           p <-
-            evalTo parseJSVal s $
+            eval s $
             newJSVal $
             codeFromValueLBS $
             encode $ String $ Text.decodeUtf8 $ LBS.toStrict $ encode v

--- a/inline-js/tests/Tests/PingPong.hs
+++ b/inline-js/tests/Tests/PingPong.hs
@@ -55,7 +55,6 @@ tests =
         run $ do
           p <-
             eval s $
-            newJSVal $
             codeFromValueLBS $
             encode $ String $ Text.decodeUtf8 $ LBS.toStrict $ encode v
           _recv_v <-

--- a/inline-js/tests/Tests/PingPong.hs
+++ b/inline-js/tests/Tests/PingPong.hs
@@ -8,11 +8,9 @@ import Control.Monad hiding (fail)
 import Control.Monad.Fail
 import Control.Monad.IO.Class (liftIO)
 import Data.Aeson
-import qualified Data.ByteString.Lazy as LBS
 import Data.Int
 import Data.Maybe
 import qualified Data.Text as Text
-import qualified Data.Text.Encoding as Text
 import GHC.Exts
 import Language.JavaScript.Inline.Command
 import Language.JavaScript.Inline.JSCode
@@ -53,12 +51,11 @@ tests =
       s <- liftIO getSetup
       forAllM genValue $ \v ->
         run $ do
-          p <-
-            eval s $
-            codeFromValueLBS $
-            encode $ String $ Text.decodeUtf8 $ LBS.toStrict $ encode v
+          v_buf_ref <- alloc s $ encode v
           _recv_v <-
-            fmap (fromJust . decode') $ eval s $ jsonStringify $ deRefJSVal p
+            fmap (fromJust . decode') $
+            eval s $
+            jsonStringify $ jsonParse $ bufferToString $ deRefJSVal v_buf_ref
           unless (v == _recv_v) $
             fail $ "pingpong: pong mismatch: " <> show (v, _recv_v)
 

--- a/inline-js/tests/Tests/PingPong.hs
+++ b/inline-js/tests/Tests/PingPong.hs
@@ -54,11 +54,11 @@ tests =
       forAllM genValue $ \v ->
         run $ do
           p <-
-            evalTo parseJSRef s $
-            newJSRef $
+            evalTo parseJSVal s $
+            newJSVal $
             codeFromValueLBS $
             encode $ String $ Text.decodeUtf8 $ LBS.toStrict $ encode v
-          _recv_v <- fmap (fromJust . decode') $ eval s $ deRefJSRef p
+          _recv_v <- fmap (fromJust . decode') $ eval s $ deRefJSVal p
           unless (v == _recv_v) $
             fail $ "pingpong: pong mismatch: " <> show (v, _recv_v)
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,8 +1,7 @@
-resolver: lts-13.14
+resolver: lts-13.15
 packages:
   - inline-js
   - inline-js-core
 nix:
-  enable: true
   packages:
     - nodejs-11_x


### PR DESCRIPTION
Notable changes:

* We used to assume all returned data is JSON-encoded and implicitly invoke `JSON.stringify()` in the eval server. Now the assumption no longer holds: `EvalResponse` is parameterised by either `ByteString` or `JSVal`, and for `EvalResponse ByteString`, the returned data is only wrapped in `Buffer.from()`, so it can be any kind of binary data. Manually call `JSON.stringify()` if JSON-encoded return data is needed.
* `newJSVal` is now implicitly called in the eval server. If we need to return a `JSVal` from node, simply make sure the response type is `EvalResponse JSVal`.
* Implemented `AllocRequest` to send a raw Haskell buffer to node.
* `JSRef`s renamed to `JSVal`s so more consistent with asterius.

The higher-level TH quotes in `inline-js` should still continue to work without modification in their use sites.