### PR TITLE
Use fds instead of stdin/stdout for Transport

### DIFF
--- a/inline-js-core/jsbits/echo.mjs
+++ b/inline-js-core/jsbits/echo.mjs
@@ -1,3 +1,4 @@
+import fs from "fs";
 import process from "process";
 import { Transport } from "./transport.mjs";
 
@@ -6,5 +7,16 @@ process.on("uncaughtException", err => {
   throw err;
 });
 
-const ipc = new Transport(process.stdin, process.stdout);
+const ipc = new Transport(
+  fs.createReadStream(null, {
+    encoding: null,
+    fd: Number.parseInt(process.argv[process.argv.length - 1]),
+    autoClose: false
+  }),
+  fs.createWriteStream(null, {
+    encoding: null,
+    fd: Number.parseInt(process.argv[process.argv.length - 2]),
+    autoClose: false
+  })
+);
 ipc.on("recv", buf => ipc.send(buf));

--- a/inline-js-core/jsbits/eval.mjs
+++ b/inline-js-core/jsbits/eval.mjs
@@ -1,3 +1,4 @@
+import fs from "fs";
 import process from "process";
 import vm from "vm";
 
@@ -21,7 +22,18 @@ global.JSVal = class {
 
 const ctx = vm.createContext(global);
 
-const ipc = new Transport(process.stdin, process.stdout);
+const ipc = new Transport(
+  fs.createReadStream(null, {
+    encoding: null,
+    fd: Number.parseInt(process.argv[process.argv.length - 1]),
+    autoClose: false
+  }),
+  fs.createWriteStream(null, {
+    encoding: null,
+    fd: Number.parseInt(process.argv[process.argv.length - 2]),
+    autoClose: false
+  })
+);
 
 function sendMsg(msg_id, ret_tag, is_err, result) {
   try {

--- a/inline-js-core/src/Language/JavaScript/Inline/Session.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Session.hs
@@ -46,6 +46,7 @@ defJSSessionOpts =
                   [ "--experimental-modules"
                   , _datadir </> "jsbits" </> "eval.mjs"
                   ]
+              , procStdOutInherit = False
               , procStdErrInherit = False
               }
         }

--- a/inline-js/tests/Tests/Echo.hs
+++ b/inline-js/tests/Tests/Echo.hs
@@ -30,6 +30,7 @@ tests =
                   [ "--experimental-modules"
                   , _datadir </> "jsbits" </> "echo.mjs"
                   ]
+              , procStdOutInherit = True
               , procStdErrInherit = True
               }
         lockSend $ strictTransport t)


### PR DESCRIPTION
When using `inline-js-core` to evaluate wasm/js produced by asterius codegen, the pipes are broken due to calling of `console` API in evaluated code. It's possible to override `console` by providing a fake `console` interface in the contexified object in the eval server, but apparently a simpler fix is creating file descriptors in Haskell, then passing those to the eval server, and stdin/stdout/stderr of node remain untouched.