### PR TITLE
Implement "importMJS" command

### DIFF
--- a/inline-js-core/jsbits/eval.mjs
+++ b/inline-js-core/jsbits/eval.mjs
@@ -1,5 +1,6 @@
 import fs from "fs";
 import process from "process";
+import url from "url";
 import vm from "vm";
 
 import context_global from "./context.mjs";
@@ -98,6 +99,13 @@ ipc.on("recv", async buf => {
       }
       case 1: {
         sendMsg(msg_id, 1, false, buf.slice(8));
+        break;
+      }
+      case 2: {
+        const import_path = decoder.decode(buf.slice(8)),
+          import_url = url.pathToFileURL(import_path).href,
+          import_result = await import(import_url);
+        sendMsg(msg_id, 1, false, import_result);
         break;
       }
       default: {

--- a/inline-js-core/src/Language/JavaScript/Inline/Command.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Command.hs
@@ -6,6 +6,7 @@ module Language.JavaScript.Inline.Command
   ( eval
   , evalAsync
   , alloc
+  , importMJS
   ) where
 
 import Control.Monad.Fail
@@ -59,3 +60,6 @@ evalAsync s c =
 
 alloc :: JSSession -> LBS.ByteString -> IO JSVal
 alloc s buf = sendRecv s AllocRequest {allocContent = buf} >>= checkEvalResponse
+
+importMJS :: JSSession -> FilePath -> IO JSVal
+importMJS s p = sendRecv s ImportRequest {importPath = p} >>= checkEvalResponse

--- a/inline-js-core/src/Language/JavaScript/Inline/Message/Eval.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Message/Eval.hs
@@ -6,6 +6,7 @@
 module Language.JavaScript.Inline.Message.Eval
   ( EvalRequest(..)
   , AllocRequest(..)
+  , ImportRequest(..)
   , EvalResponse(..)
   ) where
 
@@ -13,6 +14,8 @@ import Data.Binary.Get
 import Data.Binary.Put
 import qualified Data.ByteString.Lazy as LBS
 import Data.Coerce
+import qualified Data.Text.Lazy as LText
+import qualified Data.Text.Lazy.Encoding as LText
 import Data.Word
 import qualified Language.JavaScript.Inline.JSCode as JSCode
 import Language.JavaScript.Inline.Message.Class
@@ -25,6 +28,10 @@ data EvalRequest a = EvalRequest
 
 newtype AllocRequest = AllocRequest
   { allocContent :: LBS.ByteString
+  }
+
+newtype ImportRequest = ImportRequest
+  { importPath :: FilePath
   }
 
 data EvalResponse a
@@ -44,6 +51,11 @@ instance Request AllocRequest where
   putRequest AllocRequest {..} = do
     putWord32host 1
     putLazyByteString allocContent
+
+instance Request ImportRequest where
+  putRequest ImportRequest {..} = do
+    putWord32host 2
+    putLazyByteString $ LText.encodeUtf8 $ LText.pack importPath
 
 instance Response (EvalResponse LBS.ByteString) where
   getResponse = getResponseWith getRemainingLazyByteString

--- a/inline-js/testdata/echo.mjs
+++ b/inline-js/testdata/echo.mjs
@@ -1,0 +1,3 @@
+import { identity } from "./identity.mjs";
+
+export { identity };

--- a/inline-js/testdata/identity.mjs
+++ b/inline-js/testdata/identity.mjs
@@ -1,0 +1,3 @@
+export function identity(x) {
+  return x;
+}

--- a/inline-js/tests/Main.hs
+++ b/inline-js/tests/Main.hs
@@ -1,4 +1,5 @@
 import Test.Tasty (defaultMain, testGroup)
+import qualified Tests.Echo as Echo
 import qualified Tests.Evaluation as Evaluation
 import qualified Tests.PingPong as PingPong
 import qualified Tests.Quotation as Quotation
@@ -7,5 +8,11 @@ import qualified Tests.Wasm as Wasm
 main :: IO ()
 main = do
   tests <-
-    sequence [Evaluation.tests, PingPong.tests, Quotation.tests, Wasm.tests]
+    sequence
+      [ Echo.tests
+      , Evaluation.tests
+      , PingPong.tests
+      , Quotation.tests
+      , Wasm.tests
+      ]
   defaultMain $ testGroup "inline-js Test Suite" tests

--- a/inline-js/tests/Tests/Echo.hs
+++ b/inline-js/tests/Tests/Echo.hs
@@ -1,0 +1,36 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Tests.Echo
+  ( tests
+  ) where
+
+import Control.Monad
+import qualified Data.ByteString.Lazy as LBS
+import Language.JavaScript.Inline.Command
+import Language.JavaScript.Inline.JSCode
+import Language.JavaScript.Inline.Session
+import qualified Paths_inline_js
+import System.FilePath
+import Test.QuickCheck.Monadic
+import Test.Tasty
+import Test.Tasty.QuickCheck
+
+genLBS :: Gen LBS.ByteString
+genLBS = LBS.pack <$> vectorOf 1024 arbitrary
+
+tests :: IO TestTree
+tests = do
+  datadir <- Paths_inline_js.getDataDir
+  pure $
+    testProperty "Echo" $
+    withMaxSuccess 8 $
+    monadicIO $
+    forAllM genLBS $ \buf ->
+      run $
+      withJSSession defJSSessionOpts $ \s -> do
+        mod_ref <- importMJS s $ datadir </> "testdata" </> "echo.mjs"
+        buf_ref <- alloc s buf
+        buf' <-
+          eval s $
+          deRefJSVal mod_ref <> ".identity(" <> deRefJSVal buf_ref <> ")"
+        unless (buf' == buf) $ fail "Echo mismatch"

--- a/inline-js/tests/Tests/PingPong.hs
+++ b/inline-js/tests/Tests/PingPong.hs
@@ -46,7 +46,7 @@ tests =
   pure $
   withResource setup teardown $ \getSetup ->
     testProperty "Ping-Pong Matching" $
-    withMaxSuccess 65536 $
+    withMaxSuccess 1024 $
     monadicIO $ do
       s <- liftIO getSetup
       forAllM genValue $ \v ->


### PR DESCRIPTION
In nodejs it's a bit tricky to `import()` a script when it's in a different directory than `eval.mjs`; changing working directory only works for old-style `require()`. Now we implement that as a built-in request; given an absolute `FilePath` to an entry `.mjs`, this `import()`s the entry script along with its deps, and return as a `JSVal`.