### PR TITLE
Export a Haskell function as a JavaScript function

### DIFF
--- a/inline-js-core/inline-js-core.cabal
+++ b/inline-js-core/inline-js-core.cabal
@@ -25,10 +25,12 @@ library
       Language.JavaScript.Inline.Core
   other-modules:
       Language.JavaScript.Inline.Core.Command
+      Language.JavaScript.Inline.Core.HSCode
       Language.JavaScript.Inline.Core.Internal
       Language.JavaScript.Inline.Core.JSCode
       Language.JavaScript.Inline.Core.Message.Class
       Language.JavaScript.Inline.Core.Message.Eval
+      Language.JavaScript.Inline.Core.Message.HSCode
       Language.JavaScript.Inline.Core.MessageCounter
       Language.JavaScript.Inline.Core.Session
       Paths_inline_js_core

--- a/inline-js-core/inline-js-core.cabal
+++ b/inline-js-core/inline-js-core.cabal
@@ -23,7 +23,6 @@ source-repository head
 library
   exposed-modules:
       Language.JavaScript.Inline.Core
-      Paths_inline_js_core
   other-modules:
       Language.JavaScript.Inline.Core.Command
       Language.JavaScript.Inline.Core.Internal
@@ -32,6 +31,7 @@ library
       Language.JavaScript.Inline.Core.Message.Eval
       Language.JavaScript.Inline.Core.MessageCounter
       Language.JavaScript.Inline.Core.Session
+      Paths_inline_js_core
   autogen-modules:
       Paths_inline_js_core
   hs-source-dirs:

--- a/inline-js-core/inline-js-core.cabal
+++ b/inline-js-core/inline-js-core.cabal
@@ -23,15 +23,15 @@ source-repository head
 library
   exposed-modules:
       Language.JavaScript.Inline.Core
+      Paths_inline_js_core
+  other-modules:
       Language.JavaScript.Inline.Core.Command
+      Language.JavaScript.Inline.Core.Internal
       Language.JavaScript.Inline.Core.JSCode
       Language.JavaScript.Inline.Core.Message.Class
       Language.JavaScript.Inline.Core.Message.Eval
       Language.JavaScript.Inline.Core.MessageCounter
       Language.JavaScript.Inline.Core.Session
-      Paths_inline_js_core
-  other-modules:
-      Language.JavaScript.Inline.Core.Internal
   autogen-modules:
       Paths_inline_js_core
   hs-source-dirs:

--- a/inline-js-core/jsbits/jsval.mjs
+++ b/inline-js-core/jsbits/jsval.mjs
@@ -1,13 +1,13 @@
 class JSValManager {
   constructor() {
     this.map = new Map([[0, null]]);
-    this.last = 1;
+    this.last = 0;
     Object.seal(this);
   }
 
   newJSVal(v) {
     if (v === undefined || v === null) return 0;
-    const k = this.last++;
+    const k = (this.last += 2);
     this.map.set(k, v);
     return k;
   }

--- a/inline-js-core/src/Language/JavaScript/Inline/Core.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Core.hs
@@ -16,22 +16,28 @@ module Language.JavaScript.Inline.Core
   , deRefJSVal
   , freeJSVal
   , takeJSVal
+  , HSFunc(..)
   , Request
   , ResponseOf
   , Response
   , EvalRequest(..)
   , AllocRequest(..)
   , ImportRequest(..)
+  , ExportHSFuncRequest
   , EvalResponse(..)
   , sendMsg
   , sendRecv
   , eval
   , alloc
   , importMJS
+  , newHSFunc
+  , exportHSFunc
   ) where
 
 import Language.JavaScript.Inline.Core.Command
+import Language.JavaScript.Inline.Core.HSCode
 import Language.JavaScript.Inline.Core.JSCode
 import Language.JavaScript.Inline.Core.Message.Class
 import Language.JavaScript.Inline.Core.Message.Eval
+import Language.JavaScript.Inline.Core.Message.HSCode
 import Language.JavaScript.Inline.Core.Session

--- a/inline-js-core/src/Language/JavaScript/Inline/Core.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Core.hs
@@ -17,6 +17,7 @@ module Language.JavaScript.Inline.Core
   , freeJSVal
   , takeJSVal
   , Request
+  , ResponseOf
   , Response
   , EvalRequest(..)
   , AllocRequest(..)

--- a/inline-js-core/src/Language/JavaScript/Inline/Core/HSCode.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Core/HSCode.hs
@@ -1,0 +1,20 @@
+module Language.JavaScript.Inline.Core.HSCode
+  ( HSFunc(..)
+  , HSFuncRef(..)
+  ) where
+
+import qualified Data.ByteString.Lazy as LBS
+
+-- | The type of Haskell functions which can be exported to JavaScript.
+-- When invoked, the JavaScript wrapper function sends back the argument list;
+-- each argument is converted to binary with @Buffer.from()@.
+-- The Haskell function computes and returns the result in a forked thread.
+--
+-- Note that the JavaScript wrapper is an async function, and either
+-- resolves with the result, or rejects with an UTF-8 encoded Haskell exception.
+newtype HSFunc = HSFunc
+  { runHSFunc :: [LBS.ByteString] -> IO LBS.ByteString
+  }
+
+newtype HSFuncRef =
+  HSFuncRef Int

--- a/inline-js-core/src/Language/JavaScript/Inline/Core/Internal.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Core/Internal.hs
@@ -1,9 +1,48 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+
 module Language.JavaScript.Inline.Core.Internal
-  ( once
+  ( peekHandle
+  , hGetLBS
+  , tryAny
+  , once
   ) where
 
 import Control.Exception
+import Control.Monad
+import qualified Data.ByteString.Internal as BS
+import qualified Data.ByteString.Lazy as LBS
+import Foreign
+import System.IO
 import System.IO.Unsafe
+
+hGet' :: Handle -> Ptr a -> Int -> IO ()
+hGet' h p l = do
+  l' <- hGetBuf h p l
+  unless (l' == l) $
+    fail $ "hGet': expected " <> show l <> " bytes, got " <> show l'
+
+{-# INLINE peekHandle #-}
+peekHandle ::
+     forall a. Storable a
+  => Handle
+  -> IO a
+peekHandle h =
+  alloca $ \p -> do
+    hGet' h p (sizeOf (undefined :: a))
+    peek p
+
+{-# INLINE hGetLBS #-}
+hGetLBS :: Handle -> Int -> IO LBS.ByteString
+hGetLBS h l
+  | l < 0 = fail $ "hGetLBS: required " <> show l <> " bytes"
+  | l == 0 = pure LBS.empty
+  | otherwise = fmap LBS.fromStrict $ BS.create l $ \p -> hGet' h p l
+
+{-# INLINE tryAny #-}
+tryAny :: IO a -> IO (Either SomeException a)
+tryAny m = catch (m >>= (Right <$>) . evaluate) ((Left <$>) . w)
+  where
+    w err = catch (evaluate err) w
 
 {-# INLINE once #-}
 once :: IO a -> IO (IO a)

--- a/inline-js-core/src/Language/JavaScript/Inline/Core/Message/Class.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Core/Message/Class.hs
@@ -14,6 +14,7 @@ import Language.JavaScript.Inline.Core.MessageCounter
 
 -- | The class of supported request types.
 class Request r where
+  -- | The request type's corresponding response type.
   type ResponseOf r
   putRequest :: r -> Put
 

--- a/inline-js-core/src/Language/JavaScript/Inline/Core/Message/HSCode.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Core/Message/HSCode.hs
@@ -1,0 +1,24 @@
+{-# LANGUAGE StrictData #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Language.JavaScript.Inline.Core.Message.HSCode
+  ( ExportHSFuncRequest(..)
+  ) where
+
+import Data.Binary.Put
+import Language.JavaScript.Inline.Core.HSCode
+import Language.JavaScript.Inline.Core.JSCode
+import Language.JavaScript.Inline.Core.Message.Class
+import Language.JavaScript.Inline.Core.Message.Eval
+
+-- | Request to export an 'HSFunc' as a JavaScript wrapper function.
+-- The wrapper is returned as 'JSVal'.
+newtype ExportHSFuncRequest = ExportHSFuncRequest
+  { exportHSFuncRef :: HSFuncRef
+  }
+
+instance Request ExportHSFuncRequest where
+  type ResponseOf ExportHSFuncRequest = EvalResponse JSVal
+  putRequest ExportHSFuncRequest {exportHSFuncRef = HSFuncRef r} = do
+    putWord32host 3
+    putWord32host $ fromIntegral r

--- a/inline-js/inline-js.cabal
+++ b/inline-js/inline-js.cabal
@@ -36,8 +36,6 @@ library
   import: deps
   exposed-modules:
       Language.JavaScript.Inline
-  other-modules:
-      Paths_inline_js
   hs-source-dirs:
       src
   default-language: Haskell2010
@@ -47,6 +45,7 @@ test-suite inline-js-test-suite
   type: exitcode-stdio-1.0
   main-is: Main.hs
   other-modules:
+      Paths_inline_js
       Tests.Echo
       Tests.Evaluation
       Tests.Helpers.Message
@@ -54,6 +53,7 @@ test-suite inline-js-test-suite
       Tests.PingPong
       Tests.Quotation
       Tests.Wasm
+  autogen-modules:
       Paths_inline_js
   hs-source-dirs:
       tests

--- a/inline-js/tests/Tests/Evaluation.hs
+++ b/inline-js/tests/Tests/Evaluation.hs
@@ -11,7 +11,6 @@ import Data.Aeson
 import qualified Data.ByteString.Lazy as LBS
 import Data.Foldable
 import Language.JavaScript.Inline.Core
-import Language.JavaScript.Inline.Core.Message.Class
 import Test.Tasty (TestTree)
 import Test.Tasty.Hspec (it, shouldBe, testSpec)
 import Tests.Helpers.Message

--- a/inline-js/tests/Tests/PingPong.hs
+++ b/inline-js/tests/Tests/PingPong.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedLists #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeApplications #-}
 
 module Tests.PingPong
@@ -9,6 +11,7 @@ import Control.Monad.Fail
 import Control.Monad.IO.Class (liftIO)
 import Data.Aeson
 import Data.Int
+import Data.List
 import Data.Maybe
 import qualified Data.Text as Text
 import GHC.Exts
@@ -47,16 +50,22 @@ tests =
     withMaxSuccess 1024 $
     monadicIO $ do
       s <- liftIO getSetup
+      (f, _) <-
+        liftIO $
+        exportHSFunc s $
+        HSFunc $ \bufs -> pure $ "[" <> mconcat (intersperse "," bufs) <> "]"
       forAllM genValue $ \v ->
         run $ do
           v_buf_ref <- alloc s $ encode v
+          v_buf_ref' <-
+            eval s $ deRefJSVal f <> "(" <> takeJSVal v_buf_ref <> ")"
           _recv_v <-
             fmap (fromJust . decode') $
             eval s $
-            jsonStringify $ jsonParse $ bufferToString $ deRefJSVal v_buf_ref
-          unless (v == _recv_v) $
+            jsonStringify (jsonParse $ bufferToString $ deRefJSVal v_buf_ref')
+          unless (Array [v] == _recv_v) $
             fail $ "pingpong: pong mismatch: " <> show (v, _recv_v)
-          () <- eval s $ freeJSVal v_buf_ref
+          () <- eval s $ freeJSVal v_buf_ref'
           pure ()
 
 setup :: IO JSSession


### PR DESCRIPTION
It's possible. And needed for `ahc-iserv` to send back ghc-related queries from the node runner.

Marshaling *different* types of Haskell functions is hard though (even if you're not going as far as `singletons`-related typesafe craziness), my hardship challenge quota already ran out for this month. So right now we only support one type of Haskell function:

```
newtype HsFunc = HSFunc ([ByteString] -> IO ByteString)
```

It can be exported to JavaScript, and the wrapper function returned as `JSVal`. When the wrapper function is called, the binary argument list is sent to Haskell, the result computed and returned in a forked Haskell thread, and finally, the wrapper function's returned `Promise` either resolves or rejects.

If people need more interesting types in arguments/return value, for now, they can always manually do the wrapping on both Haskell/JavaScript side.