### PR TITLE
Implement "sync mode" of exporting Haskell functions to JavaScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ The `expr`/`block` QuasiQuoters in `inline-js` pass JSON data between Haskell/Ja
 * Run dynamic `import()` to import a built-in module, npm module in `node_modules`, or a `.mjs` module file.
 * Specify evaluate/resolve timeouts when evaluating JavaScript.
 * Decouple the send/receive processes, so it's possible to asynchronously send a batch of requests and later retrieve the responses.
+* Exporting a Haskell function as a JavaScript function. It's even possible to make the JavaScript function *synchronous* so it can be used as a WebAssembly import!
 * Manipulate `stdin`/`stdout`/`stderr` handles of the underlying `node` process.
 
 See the haddock documentation of `Language.JavaScript.Inline.Core` for details. If you're using `inline-js`, `Language.JavaScript.Inline` also re-exports that module.

--- a/inline-js-core/jsbits/eval.mjs
+++ b/inline-js-core/jsbits/eval.mjs
@@ -1,100 +1,50 @@
-import fs from "fs";
+import path from "path";
 import process from "process";
 import { StringDecoder } from "string_decoder";
 import url from "url";
 import vm from "vm";
+import { Worker } from "worker_threads";
 
 import context_global from "./context.mjs";
-import { Transport } from "./transport.mjs";
 
 process.on("uncaughtException", err => {
   process.stderr.write(err.stack);
   throw err;
 });
 
-const ctx = vm.createContext(context_global);
-
-const ipc = new Transport(
-  fs.createReadStream(null, {
-    encoding: null,
-    fd: Number.parseInt(process.argv[process.argv.length - 1]),
-    autoClose: false
-  }),
-  fs.createWriteStream(null, {
-    encoding: null,
-    fd: Number.parseInt(process.argv[process.argv.length - 2]),
-    autoClose: false
-  })
-);
-
-function bufferFromU32(x) {
-  const buf = Buffer.allocUnsafe(4);
-  buf.writeUInt32LE(x, 0);
-  return buf;
-}
+const ctx = vm.createContext(context_global),
+  decoder = new StringDecoder("utf8"),
+  ipc = new Worker(
+    path.join(
+      path.dirname(url.fileURLToPath(import.meta.url)),
+      "transport.mjs"
+    ),
+    {
+      workerData: [
+        Number.parseInt(process.argv[process.argv.length - 1]),
+        Number.parseInt(process.argv[process.argv.length - 2])
+      ]
+    }
+  );
 
 function sendMsg(msg_id, ret_tag, is_err, result) {
-  try {
-    switch (ret_tag) {
-      case 0: {
-        const result_buf = Buffer.from(result),
-          msg_buf = Buffer.allocUnsafe(8 + result_buf.length);
-        msg_buf.writeUInt32LE(msg_id, 0);
-        msg_buf.writeUInt32LE(Number(is_err), 4);
-        result_buf.copy(msg_buf, 8);
-        ipc.send(msg_buf);
-        break;
-      }
-      case 1: {
-        const msg_buf = Buffer.allocUnsafe(12);
-        msg_buf.writeUInt32LE(msg_id, 0);
-        msg_buf.writeUInt32LE(0, 4);
-        msg_buf.writeUInt32LE(ctx.JSVal.newJSVal(result), 8);
-        ipc.send(msg_buf);
-        break;
-      }
-      case 2: {
-        const msg_buf = Buffer.allocUnsafe(8);
-        msg_buf.writeUInt32LE(msg_id, 0);
-        msg_buf.writeUInt32LE(0, 4);
-        ipc.send(msg_buf);
-        break;
-      }
-      case 3: {
-        const [hs_func_ref, args] = result,
-          buf_args = args.flatMap(arg => {
-            const raw_buf = Buffer.from(arg);
-            return [bufferFromU32(raw_buf.length), raw_buf];
-          });
-        buf_args.unshift(
-          bufferFromU32(msg_id),
-          bufferFromU32(hs_func_ref),
-          bufferFromU32(args.length)
-        );
-        ipc.send(Buffer.concat(buf_args));
-        break;
-      }
-      default: {
-        throw new Error(`Unsupported ret_tag ${ret_tag}`);
-      }
-    }
-  } catch (err) {
-    sendMsg(msg_id, 0, true, err.toString());
-  }
+  ipc.postMessage([
+    msg_id,
+    ret_tag,
+    is_err,
+    ret_tag === 1 ? ctx.JSVal.newJSVal(result) : result
+  ]);
 }
 
-const decoder = new StringDecoder("utf8");
-
-ipc.on("recv", async buf => {
-  const msg_id = buf.readUInt32LE(0);
+ipc.on("message", async ([msg_id, msg_tag, buf]) => {
   try {
-    const msg_tag = buf.readUInt32LE(4);
+    buf = Buffer.from(buf);
     switch (msg_tag) {
       case 0: {
-        const ret_tag = buf.readUInt32LE(8),
-          eval_timeout = buf.readUInt32LE(12),
-          resolve_timeout = buf.readUInt32LE(16),
-          msg_content = decoder.end(buf.slice(20)),
+        const ret_tag = buf.readUInt32LE(0),
+          eval_timeout = buf.readUInt32LE(4),
+          resolve_timeout = buf.readUInt32LE(8),
+          msg_content = decoder.end(buf.slice(12)),
           eval_options = {
             displayErrors: true,
             importModuleDynamically: spec => import(spec)
@@ -117,18 +67,18 @@ ipc.on("recv", async buf => {
         break;
       }
       case 1: {
-        sendMsg(msg_id, 1, false, buf.slice(8));
+        sendMsg(msg_id, 1, false, buf);
         break;
       }
       case 2: {
-        const import_path = decoder.end(buf.slice(8)),
+        const import_path = decoder.end(buf),
           import_url = url.pathToFileURL(import_path).href,
           import_result = await import(import_url);
         sendMsg(msg_id, 1, false, import_result);
         break;
       }
       case 3: {
-        const hs_func_ref = buf.readUInt32LE(8);
+        const hs_func_ref = buf.readUInt32LE(0);
         sendMsg(
           msg_id,
           1,
@@ -143,8 +93,8 @@ ipc.on("recv", async buf => {
       }
       case 4: {
         const [resolve, reject] = ctx.JSVal.takeJSVal(msg_id),
-          is_err = Boolean(buf.readUInt32LE(8)),
-          hs_result = buf.slice(12);
+          is_err = Boolean(buf.readUInt32LE(0)),
+          hs_result = buf.slice(4);
         (is_err ? reject : resolve)(hs_result);
         break;
       }

--- a/inline-js-core/jsbits/eval.mjs
+++ b/inline-js-core/jsbits/eval.mjs
@@ -17,7 +17,11 @@ const ctx = vm.createContext(context_global),
   shared_futex = new Int32Array(new SharedArrayBuffer(4)),
   shared_flag = new Int32Array(new SharedArrayBuffer(4)),
   shared_msg_len = new Int32Array(new SharedArrayBuffer(4)),
-  shared_msg_buf = new Uint8Array(new SharedArrayBuffer(1048576)),
+  shared_msg_buf = new Uint8Array(
+    new SharedArrayBuffer(
+      Number.parseInt(process.argv[process.argv.length - 3]) * 1048576
+    )
+  ),
   ipc = new Worker(
     path.join(
       path.dirname(url.fileURLToPath(import.meta.url)),

--- a/inline-js-core/jsbits/transport.mjs
+++ b/inline-js-core/jsbits/transport.mjs
@@ -1,10 +1,19 @@
-import assert from "assert";
-import { EventEmitter } from "events";
+import fs from "fs";
+import { parentPort, workerData } from "worker_threads";
 
-export class Transport extends EventEmitter {
+function bufferFromU32(x) {
+  const buf = Buffer.allocUnsafe(4);
+  buf.writeUInt32LE(x, 0);
+  return buf;
+}
+
+class Transport {
   constructor(i, o) {
-    super();
-    this.i = i;
+    this.i = fs.createReadStream(null, {
+      encoding: null,
+      fd: i,
+      autoClose: false
+    });
     this.o = o;
     this.iMsgLen = 0;
     this.iRest = Buffer.allocUnsafe(0);
@@ -15,30 +24,67 @@ export class Transport extends EventEmitter {
         if (!this.iMsgLen) {
           if (this.iRest.length < 4) break;
           this.iMsgLen = this.iRest.readUInt32LE(0);
-          assert(this.iMsgLen > 0);
           this.iRest = this.iRest.slice(4);
         }
         if (this.iRest.length < this.iMsgLen) break;
-        this.emit("recv", this.iRest.slice(0, this.iMsgLen));
+        const msg_buf = this.iRest.slice(0, this.iMsgLen),
+          msg_id = msg_buf.readUInt32LE(0),
+          msg_tag = msg_buf.readUInt32LE(4);
+        parentPort.postMessage([msg_id, msg_tag, msg_buf.slice(8)]);
         this.iRest = this.iRest.slice(this.iMsgLen);
         this.iMsgLen = 0;
       }
     });
-    this.i.on("error", err => this.emit("error", err));
-    this.o.on("error", err => this.emit("error", err));
-  }
-
-  send(buf) {
-    return new Promise((resolve, reject) => {
-      const nbuf = Buffer.allocUnsafe(buf.length + 4);
-      nbuf.writeUInt32LE(buf.length);
-      buf.copy(nbuf, 4);
-      this.o.write(nbuf, err => {
-        if (typeof err === "undefined") {
-          this.emit("send", buf);
-          resolve();
-        } else reject(err);
-      });
-    });
   }
 }
+
+const ipc = new Transport(workerData[0], workerData[1]);
+
+parentPort.on("message", ([msg_id, ret_tag, is_err, result]) => {
+  let buf;
+  switch (ret_tag) {
+    case 0: {
+      const result_buf = Buffer.from(result),
+        msg_buf = Buffer.allocUnsafe(8 + result_buf.length);
+      msg_buf.writeUInt32LE(msg_id, 0);
+      msg_buf.writeUInt32LE(Number(is_err), 4);
+      result_buf.copy(msg_buf, 8);
+      buf = msg_buf;
+      break;
+    }
+    case 1: {
+      const msg_buf = Buffer.allocUnsafe(12);
+      msg_buf.writeUInt32LE(msg_id, 0);
+      msg_buf.writeUInt32LE(0, 4);
+      msg_buf.writeUInt32LE(result, 8);
+      buf = msg_buf;
+      break;
+    }
+    case 2: {
+      const msg_buf = Buffer.allocUnsafe(8);
+      msg_buf.writeUInt32LE(msg_id, 0);
+      msg_buf.writeUInt32LE(0, 4);
+      buf = msg_buf;
+      break;
+    }
+    case 3: {
+      const [hs_func_ref, args] = result,
+        buf_args = args.flatMap(arg => {
+          const raw_buf = Buffer.from(arg);
+          return [bufferFromU32(raw_buf.length), raw_buf];
+        });
+      buf_args.unshift(
+        bufferFromU32(msg_id),
+        bufferFromU32(hs_func_ref),
+        bufferFromU32(args.length)
+      );
+      buf = Buffer.concat(buf_args);
+      break;
+    }
+    default: {
+      throw new Error(`Unsupported ret_tag ${ret_tag}`);
+    }
+  }
+  fs.writeSync(ipc.o, bufferFromU32(buf.length));
+  fs.writeSync(ipc.o, buf);
+});

--- a/inline-js-core/src/Language/JavaScript/Inline/Core.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Core.hs
@@ -32,6 +32,7 @@ module Language.JavaScript.Inline.Core
   , importMJS
   , newHSFunc
   , exportHSFunc
+  , exportSyncHSFunc
   ) where
 
 import Language.JavaScript.Inline.Core.Command

--- a/inline-js-core/src/Language/JavaScript/Inline/Core/Command.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Core/Command.hs
@@ -78,6 +78,9 @@ exportHSFunc s f = do
   v <- sendRecv s r >>= checkEvalResponse
   pure (v, fin)
 
+-- | Like 'exportHSFunc', except the JavaScript function is made synchronous.
+-- Very heavy hammer, only use as a last resort,
+-- and make sure the result's length doesn't exceed 'nodeSharedMemSize'.
 exportSyncHSFunc :: JSSession -> HSFunc -> IO (JSVal, IO ())
 exportSyncHSFunc s f = do
   (r, fin) <- newHSFunc s True f

--- a/inline-js-core/src/Language/JavaScript/Inline/Core/Command.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Core/Command.hs
@@ -8,6 +8,7 @@ module Language.JavaScript.Inline.Core.Command
   , alloc
   , importMJS
   , exportHSFunc
+  , exportSyncHSFunc
   ) where
 
 import Control.Monad.Fail
@@ -73,6 +74,12 @@ importMJS s p = do
 -- Throws in Haskell if the response indicates a failure.
 exportHSFunc :: JSSession -> HSFunc -> IO (JSVal, IO ())
 exportHSFunc s f = do
-  (r, fin) <- newHSFunc s f
+  (r, fin) <- newHSFunc s False f
+  v <- sendRecv s r >>= checkEvalResponse
+  pure (v, fin)
+
+exportSyncHSFunc :: JSSession -> HSFunc -> IO (JSVal, IO ())
+exportSyncHSFunc s f = do
+  (r, fin) <- newHSFunc s True f
   v <- sendRecv s r >>= checkEvalResponse
   pure (v, fin)

--- a/inline-js-core/src/Language/JavaScript/Inline/Core/HSCode.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Core/HSCode.hs
@@ -10,8 +10,9 @@ import qualified Data.ByteString.Lazy as LBS
 -- each argument is converted to binary with @Buffer.from()@.
 -- The Haskell function computes and returns the result in a forked thread.
 --
--- Note that the JavaScript wrapper is an async function, and either
--- resolves with the result, or rejects with an UTF-8 encoded Haskell exception.
+-- Note that the JavaScript wrapper is an async function by default, and returns a
+-- @Promise@ which either resolves with a @Buffer@ result,
+-- or rejects with an UTF-8 encoded Haskell exception.
 newtype HSFunc = HSFunc
   { runHSFunc :: [LBS.ByteString] -> IO LBS.ByteString
   }

--- a/inline-js-core/src/Language/JavaScript/Inline/Core/Message/HSCode.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Core/Message/HSCode.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE StrictData #-}
 {-# LANGUAGE TypeFamilies #-}
 
@@ -13,12 +14,16 @@ import Language.JavaScript.Inline.Core.Message.Eval
 
 -- | Request to export an 'HSFunc' as a JavaScript wrapper function.
 -- The wrapper is returned as 'JSVal'.
-newtype ExportHSFuncRequest = ExportHSFuncRequest
-  { exportHSFuncRef :: HSFuncRef
+data ExportHSFuncRequest = ExportHSFuncRequest
+  { sync :: Bool
+  , exportHSFuncRef :: HSFuncRef
   }
 
 instance Request ExportHSFuncRequest where
   type ResponseOf ExportHSFuncRequest = EvalResponse JSVal
-  putRequest ExportHSFuncRequest {exportHSFuncRef = HSFuncRef r} = do
-    putWord32host 3
+  putRequest ExportHSFuncRequest {exportHSFuncRef = HSFuncRef r, ..} = do
+    putWord32host $
+      if sync
+        then 5
+        else 3
     putWord32host $ fromIntegral r

--- a/inline-js-core/src/Language/JavaScript/Inline/Core/Session.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Core/Session.hs
@@ -233,9 +233,9 @@ sendRecv s = join . sendMsg s
 -- returns the request to actually make the JavaScript wrapper and the finalizer.
 --
 -- In most cases you just need the synchronous 'Language.JavaScript.Inline.Core.exportHSFunc'.
-newHSFunc :: JSSession -> HSFunc -> IO (ExportHSFuncRequest, IO ())
-newHSFunc JSSession {..} f =
+newHSFunc :: JSSession -> Bool -> HSFunc -> IO (ExportHSFuncRequest, IO ())
+newHSFunc JSSession {..} s f =
   atomicModifyIORef' hsFuncs $ \(m, l) ->
     ( (IntMap.insert l f m, succ l)
-    , ( coerce l
+    , ( ExportHSFuncRequest {sync = s, exportHSFuncRef = coerce l}
       , atomicModifyIORef' hsFuncs $ \(m', l') -> ((IntMap.delete l m', l'), ())))


### PR DESCRIPTION
As a sequel of #20.

Consider this use case: export a Haskell function, then use it as a WebAssembly import. This won't work yet since the wrapper function returns a `Promise` and is async by nature, and both the WebAssembly spec and V8 doesn't allow using async functions as imports, since that requires "suspending"/"resuming" of WebAssembly runtime state. So we need to implement a "sync mode" for this exact corner case.

Basic ideas:

* It's possibly simpler to rely on something like `fibers`, but they rely on building C++ which introduces extra pain, so we'll base on something simpler here: worker threads.
* Main logic of the "eval server" (e.g. eval/resolution, JSVal) stays in the main thread. The "transport" logic is moved to a worker thread.
* The two threads synchronize on a "shared memory" used to pass the "sync mode" Haskell function result. When a "sync mode" JavaScript call occurs, the main thread synchronously waits for the transport thread to pass back the result.
* No more than 1 "sync mode" call may happen concurrently.