### PR TITLE
Add stack traces to eval server's returned error message

### DIFF
--- a/inline-js-core/jsbits/eval.mjs
+++ b/inline-js-core/jsbits/eval.mjs
@@ -162,6 +162,6 @@ ipc.on("message", async ([msg_id, msg_tag, buf]) => {
       }
     }
   } catch (err) {
-    ipc.postMessage([msg_id, true, err.toString()]);
+    ipc.postMessage([msg_id, true, err.stack ? err.stack : err.toString()]);
   }
 });

--- a/inline-js-core/src/Language/JavaScript/Inline/Core.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Core.hs
@@ -17,6 +17,7 @@ module Language.JavaScript.Inline.Core
   , freeJSVal
   , takeJSVal
   , HSFunc(..)
+  , EvalException(..)
   , eval
   , evalWithTimeout
   , alloc


### PR DESCRIPTION
This PR adds stack traces to the returned error message when it's available. There's also an `EvalException` exception type added, which can be caught when using high-level commands like `eval` to obtain the raw error message.