### PR TITLE
Enforce correct node version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
               nixpkgs.openssh \
               nixpkgs.python3
             cd /usr
-            curl https://raw.githubusercontent.com/tweag/asterius/master/utils/v8-node.py | sh
+            curl -L https://raw.githubusercontent.com/tweag/asterius/master/utils/v8-node.py | python3
             cd $CIRCLE_WORKING_DIRECTORY
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,36 @@
 version: 2
 
 jobs:
+  inline-js-test-nix-nodejs-v8:
+    docker:
+      - image: terrorjack/pixie:debian
+    resource_class: xlarge
+    steps:
+      - run:
+          name: Install dependencies
+          command: |
+            apt update
+            apt full-upgrade -y
+            nix-channel --add https://releases.nixos.org/nixpkgs/nixpkgs-19.09pre185543.2af67605413 nixpkgs
+            nix-channel --update
+            nix-env -u
+            nix-env -iA \
+              nixpkgs.curl \
+              nixpkgs.gitMinimal \
+              nixpkgs.openssh \
+              nixpkgs.python3
+            cd /usr
+            curl https://raw.githubusercontent.com/tweag/asterius/master/utils/v8-node.py | sh
+            cd $CIRCLE_WORKING_DIRECTORY
+      - checkout
+      - run:
+          name: Test inline-js
+          command: |
+            nix-shell \
+              --command "cabal new-run inline-js:inline-js-test-suite -- -j8" \
+              -p cabal-install \
+              -p "haskellPackages.ghcWithPackages (pkgs: [pkgs.aeson pkgs.base64-bytestring pkgs.language-javascript pkgs.tasty-hspec pkgs.tasty-quickcheck pkgs.tasty-smallcheck])"
+
   inline-js-test-nix-nodejs-12:
     docker:
       - image: terrorjack/pixie:latest
@@ -77,6 +107,7 @@ workflows:
   version: 2
   build:
     jobs:
+      - inline-js-test-nix-nodejs-v8
       - inline-js-test-nix-nodejs-12
       - inline-js-test-nix-nodejs-11
       - inline-js-test-stack

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2
 
 jobs:
-  inline-js-test-nix:
+  inline-js-test-nix-nodejs-12:
     docker:
       - image: terrorjack/pixie:latest
     resource_class: xlarge
@@ -24,6 +24,56 @@ jobs:
               --pure \
               -p cabal-install \
               -p nodejs-12_x \
+              -p "haskellPackages.ghcWithPackages (pkgs: [pkgs.aeson pkgs.base64-bytestring pkgs.language-javascript pkgs.tasty-hspec pkgs.tasty-quickcheck pkgs.tasty-smallcheck])"
+
+  inline-js-test-nix-nodejs-11:
+    docker:
+      - image: terrorjack/pixie:latest
+    resource_class: xlarge
+    steps:
+      - run:
+          name: Install dependencies
+          command: |
+            nix-channel --add https://releases.nixos.org/nixpkgs/nixpkgs-19.09pre185427.eadc8510514 nixpkgs
+            nix-channel --update
+            nix-env -u
+            nix-env -iA \
+              nixpkgs.gitMinimal \
+              nixpkgs.openssh
+      - checkout
+      - run:
+          name: Test inline-js
+          command: |
+            nix-shell \
+              --command "cabal new-run inline-js:inline-js-test-suite -- -j8" \
+              --pure \
+              -p cabal-install \
+              -p nodejs-11_x \
+              -p "haskellPackages.ghcWithPackages (pkgs: [pkgs.aeson pkgs.base64-bytestring pkgs.language-javascript pkgs.tasty-hspec pkgs.tasty-quickcheck pkgs.tasty-smallcheck])"
+
+  inline-js-test-nix-nodejs-10:
+    docker:
+      - image: terrorjack/pixie:latest
+    resource_class: xlarge
+    steps:
+      - run:
+          name: Install dependencies
+          command: |
+            nix-channel --add https://releases.nixos.org/nixpkgs/nixpkgs-19.09pre185427.eadc8510514 nixpkgs
+            nix-channel --update
+            nix-env -u
+            nix-env -iA \
+              nixpkgs.gitMinimal \
+              nixpkgs.openssh
+      - checkout
+      - run:
+          name: Test inline-js
+          command: |
+            nix-shell \
+              --command "cabal new-run inline-js:inline-js-test-suite -- -j8" \
+              --pure \
+              -p cabal-install \
+              -p nodejs-10_x \
               -p "haskellPackages.ghcWithPackages (pkgs: [pkgs.aeson pkgs.base64-bytestring pkgs.language-javascript pkgs.tasty-hspec pkgs.tasty-quickcheck pkgs.tasty-smallcheck])"
 
   inline-js-test-stack:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,5 +102,7 @@ workflows:
   version: 2
   build:
     jobs:
-      - inline-js-test-nix
+      - inline-js-test-nix-nodejs-12
+      - inline-js-test-nix-nodejs-11
+      - inline-js-test-nix-nodejs-10
       - inline-js-test-stack

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,8 @@ jobs:
               nixpkgs.python3
             cd /usr
             curl -L https://raw.githubusercontent.com/tweag/asterius/master/utils/v8-node.py | python3
+            export npm_config_prefix=/usr
+            curl -L https://www.npmjs.com/install.sh | sh
       - checkout
       - run:
           name: Test inline-js

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
       - run:
           name: Install dependencies
           command: |
-            nix-channel --add https://releases.nixos.org/nixpkgs/nixpkgs-19.09pre180124.920d066ded1 nixpkgs
+            nix-channel --add https://releases.nixos.org/nixpkgs/nixpkgs-19.09pre185427.eadc8510514 nixpkgs
             nix-channel --update
             nix-env -u
             nix-env -iA \
@@ -34,7 +34,7 @@ jobs:
       - run:
           name: Install dependencies
           command: |
-            nix-channel --add https://releases.nixos.org/nixpkgs/nixpkgs-19.09pre180124.920d066ded1 nixpkgs
+            nix-channel --add https://releases.nixos.org/nixpkgs/nixpkgs-19.09pre185427.eadc8510514 nixpkgs
             nix-channel --update
             nix-env -u
             nix-env -iA \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,6 @@ jobs:
               nixpkgs.python3
             cd /usr
             curl -L https://raw.githubusercontent.com/tweag/asterius/master/utils/v8-node.py | python3
-            cd $CIRCLE_WORKING_DIRECTORY
       - checkout
       - run:
           name: Test inline-js

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
       - run:
           name: Install dependencies
           command: |
-            nix-channel --add https://releases.nixos.org/nixpkgs/nixpkgs-19.09pre185427.eadc8510514 nixpkgs
+            nix-channel --add https://releases.nixos.org/nixpkgs/nixpkgs-19.09pre185543.2af67605413 nixpkgs
             nix-channel --update
             nix-env -u
             nix-env -iA \
@@ -51,31 +51,6 @@ jobs:
               -p nodejs-11_x \
               -p "haskellPackages.ghcWithPackages (pkgs: [pkgs.aeson pkgs.base64-bytestring pkgs.language-javascript pkgs.tasty-hspec pkgs.tasty-quickcheck pkgs.tasty-smallcheck])"
 
-  inline-js-test-nix-nodejs-10:
-    docker:
-      - image: terrorjack/pixie:latest
-    resource_class: xlarge
-    steps:
-      - run:
-          name: Install dependencies
-          command: |
-            nix-channel --add https://releases.nixos.org/nixpkgs/nixpkgs-19.09pre185427.eadc8510514 nixpkgs
-            nix-channel --update
-            nix-env -u
-            nix-env -iA \
-              nixpkgs.gitMinimal \
-              nixpkgs.openssh
-      - checkout
-      - run:
-          name: Test inline-js
-          command: |
-            nix-shell \
-              --command "cabal new-run inline-js:inline-js-test-suite -- -j8" \
-              --pure \
-              -p cabal-install \
-              -p nodejs-10_x \
-              -p "haskellPackages.ghcWithPackages (pkgs: [pkgs.aeson pkgs.base64-bytestring pkgs.language-javascript pkgs.tasty-hspec pkgs.tasty-quickcheck pkgs.tasty-smallcheck])"
-
   inline-js-test-stack:
     docker:
       - image: terrorjack/pixie:latest
@@ -84,7 +59,7 @@ jobs:
       - run:
           name: Install dependencies
           command: |
-            nix-channel --add https://releases.nixos.org/nixpkgs/nixpkgs-19.09pre185427.eadc8510514 nixpkgs
+            nix-channel --add https://releases.nixos.org/nixpkgs/nixpkgs-19.09pre185543.2af67605413 nixpkgs
             nix-channel --update
             nix-env -u
             nix-env -iA \
@@ -104,5 +79,4 @@ workflows:
     jobs:
       - inline-js-test-nix-nodejs-12
       - inline-js-test-nix-nodejs-11
-      - inline-js-test-nix-nodejs-10
       - inline-js-test-stack

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Important note: do not run untrusted JavaScript via `inline-js-core`/`inline-js`
 
 Simply `stack build` shall do. Run `stack test inline-js` to run the test suite, `stack test inline-js --test-arguments="-j8"` for parallel testing. `cabal new-build` should also work.
 
-A recent version of `node` and `npm` is required in `PATH`. We test against the latest version of Node.js and Stackage LTS resolver on CircleCI.
+`inline-js-core`/`inline-js` requires at least nodejs 11 to work; earlier versions will be rejected upon initialization of `JSSession`.
 
 ## Sponsors
 

--- a/inline-js-core/inline-js-core.cabal
+++ b/inline-js-core/inline-js-core.cabal
@@ -32,6 +32,7 @@ library
       Language.JavaScript.Inline.Core.Message.Eval
       Language.JavaScript.Inline.Core.Message.HSCode
       Language.JavaScript.Inline.Core.MessageCounter
+      Language.JavaScript.Inline.Core.NodeVersion
       Language.JavaScript.Inline.Core.Session
       Paths_inline_js_core
   autogen-modules:

--- a/inline-js-core/src/Language/JavaScript/Inline/Core/NodeVersion.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Core/NodeVersion.hs
@@ -9,14 +9,20 @@ import Data.Version
 import System.Process
 
 split :: (a -> Bool) -> [a] -> [[a]]
-split f = foldr w []
+split f l =
+  case foldr w [] l of
+    []:r -> r
+    r -> r
   where
     w x acc
-      | f x = [] : acc
+      | f x =
+        case acc of
+          (_:_):_ -> [] : acc
+          _ -> acc
       | otherwise =
         case acc of
-          xs:acc' -> (x : xs) : acc'
           [] -> [[x]]
+          xs:acc' -> (x : xs) : acc'
 
 nodeVersion :: FilePath -> IO Version
 nodeVersion p = do

--- a/inline-js-core/src/Language/JavaScript/Inline/Core/NodeVersion.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Core/NodeVersion.hs
@@ -1,0 +1,32 @@
+{-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
+
+module Language.JavaScript.Inline.Core.NodeVersion
+  ( checkNodeVersion
+  ) where
+
+import Control.Monad
+import Data.Version
+import System.Process
+
+split :: (a -> Bool) -> [a] -> [[a]]
+split f = foldr w []
+  where
+    w x acc
+      | f x = [] : acc
+      | otherwise =
+        case acc of
+          xs:acc' -> (x : xs) : acc'
+          [] -> [[x]]
+
+nodeVersion :: FilePath -> IO Version
+nodeVersion p = do
+  ('v':s) <- readProcess p ["--version"] ""
+  let vs:tags = split (== '-') s
+      v = map read $ split (== '.') vs
+  pure $ Version v tags
+
+checkNodeVersion :: FilePath -> IO ()
+checkNodeVersion p = do
+  v <- nodeVersion p
+  unless (v >= Version [11] []) $
+    fail $ "Detected node version " <> show v <> ", requires at least node 11"

--- a/inline-js-core/src/Language/JavaScript/Inline/Core/Session.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Core/Session.hs
@@ -37,6 +37,7 @@ import Language.JavaScript.Inline.Core.Internal
 import Language.JavaScript.Inline.Core.Message.Class
 import Language.JavaScript.Inline.Core.Message.HSCode
 import Language.JavaScript.Inline.Core.MessageCounter
+import Language.JavaScript.Inline.Core.NodeVersion
 import qualified Paths_inline_js_core
 import System.Directory
 import System.FilePath
@@ -89,6 +90,7 @@ data JSSession = JSSession
 -- | Initializes a new 'JSSession'.
 newJSSession :: JSSessionOpts -> IO JSSession
 newJSSession JSSessionOpts {..} = do
+  checkNodeVersion nodePath
   (mjss_dir, mjss) <-
     do mjss_dir <- (</> "jsbits") <$> Paths_inline_js_core.getDataDir
        case nodeWorkDir of

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-13.21
+resolver: lts-13.28
 packages:
   - inline-js
   - inline-js-core


### PR DESCRIPTION
This PR ensures the node version is at least 11; otherwise `JSSession` initialization will fail. The node version requirement is now written on readme.

Also, we test against node 11/12/13 on CI. Node 13 is provided by V8 team's node integration build.