### PR TITLE
Misc improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,14 +4,13 @@ jobs:
   inline-js-test-nix-nodejs-v8:
     docker:
       - image: terrorjack/pixie:debian
-    resource_class: xlarge
     steps:
       - run:
           name: Install dependencies
           command: |
             apt update
             apt full-upgrade -y
-            nix-channel --add https://releases.nixos.org/nixpkgs/nixpkgs-19.09pre185543.2af67605413 nixpkgs
+            nix-channel --add https://releases.nixos.org/nixpkgs/nixpkgs-19.09pre190327.54f385241e6 nixpkgs
             nix-channel --update
             nix-env -u
             nix-env -iA \
@@ -28,19 +27,18 @@ jobs:
           name: Test inline-js
           command: |
             nix-shell \
-              --command "cabal new-run inline-js:inline-js-test-suite -- -j8" \
+              --command "cabal new-run -j2 inline-js:inline-js-test-suite -- -j2" \
               -p cabal-install \
               -p "haskellPackages.ghcWithPackages (pkgs: [pkgs.aeson pkgs.base64-bytestring pkgs.language-javascript pkgs.tasty-hspec pkgs.tasty-quickcheck pkgs.tasty-smallcheck])"
 
   inline-js-test-nix-nodejs-12:
     docker:
       - image: terrorjack/pixie:latest
-    resource_class: xlarge
     steps:
       - run:
           name: Install dependencies
           command: |
-            nix-channel --add https://releases.nixos.org/nixpkgs/nixpkgs-19.09pre185543.2af67605413 nixpkgs
+            nix-channel --add https://releases.nixos.org/nixpkgs/nixpkgs-19.09pre190327.54f385241e6 nixpkgs
             nix-channel --update
             nix-env -u
             nix-env -iA \
@@ -51,46 +49,20 @@ jobs:
           name: Test inline-js
           command: |
             nix-shell \
-              --command "cabal new-run inline-js:inline-js-test-suite -- -j8" \
+              --command "cabal new-run -j2 inline-js:inline-js-test-suite -- -j2" \
               --pure \
               -p cabal-install \
               -p nodejs-12_x \
               -p "haskellPackages.ghcWithPackages (pkgs: [pkgs.aeson pkgs.base64-bytestring pkgs.language-javascript pkgs.tasty-hspec pkgs.tasty-quickcheck pkgs.tasty-smallcheck])"
 
-  inline-js-test-nix-nodejs-11:
-    docker:
-      - image: terrorjack/pixie:latest
-    resource_class: xlarge
-    steps:
-      - run:
-          name: Install dependencies
-          command: |
-            nix-channel --add https://releases.nixos.org/nixpkgs/nixpkgs-19.09pre185427.eadc8510514 nixpkgs
-            nix-channel --update
-            nix-env -u
-            nix-env -iA \
-              nixpkgs.gitMinimal \
-              nixpkgs.openssh
-      - checkout
-      - run:
-          name: Test inline-js
-          command: |
-            nix-shell \
-              --command "cabal new-run inline-js:inline-js-test-suite -- -j8" \
-              --pure \
-              -p cabal-install \
-              -p nodejs-11_x \
-              -p "haskellPackages.ghcWithPackages (pkgs: [pkgs.aeson pkgs.base64-bytestring pkgs.language-javascript pkgs.tasty-hspec pkgs.tasty-quickcheck pkgs.tasty-smallcheck])"
-
   inline-js-test-stack:
     docker:
       - image: terrorjack/pixie:latest
-    resource_class: xlarge
     steps:
       - run:
           name: Install dependencies
           command: |
-            nix-channel --add https://releases.nixos.org/nixpkgs/nixpkgs-19.09pre185543.2af67605413 nixpkgs
+            nix-channel --add https://releases.nixos.org/nixpkgs/nixpkgs-19.09pre190327.54f385241e6 nixpkgs
             nix-channel --update
             nix-env -u
             nix-env -iA \
@@ -102,7 +74,7 @@ jobs:
           name: Test inline-js
           command: |
             stack --nix --no-nix-pure --no-terminal build --haddock --test --no-run-tests
-            stack --nix --no-nix-pure --no-terminal test inline-js --test-arguments="-j8"
+            stack --nix --no-nix-pure --no-terminal test inline-js --test-arguments="-j2"
 
 workflows:
   version: 2
@@ -110,5 +82,4 @@ workflows:
     jobs:
       - inline-js-test-nix-nodejs-v8
       - inline-js-test-nix-nodejs-12
-      - inline-js-test-nix-nodejs-11
       - inline-js-test-stack

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
             nix-shell \
               --command "cabal new-run -j2 inline-js:inline-js-test-suite -- -j2" \
               -p cabal-install \
-              -p "haskellPackages.ghcWithPackages (pkgs: [pkgs.aeson pkgs.base64-bytestring pkgs.language-javascript pkgs.tasty-hspec pkgs.tasty-quickcheck pkgs.tasty-smallcheck])"
+              -p "haskellPackages.ghcWithPackages (pkgs: [pkgs.aeson pkgs.base64-bytestring pkgs.language-javascript pkgs.tasty-hunit pkgs.tasty-quickcheck pkgs.tasty-smallcheck])"
 
   inline-js-test-nix-nodejs-12:
     docker:
@@ -53,7 +53,7 @@ jobs:
               --pure \
               -p cabal-install \
               -p nodejs-12_x \
-              -p "haskellPackages.ghcWithPackages (pkgs: [pkgs.aeson pkgs.base64-bytestring pkgs.language-javascript pkgs.tasty-hspec pkgs.tasty-quickcheck pkgs.tasty-smallcheck])"
+              -p "haskellPackages.ghcWithPackages (pkgs: [pkgs.aeson pkgs.base64-bytestring pkgs.language-javascript pkgs.tasty-hunit pkgs.tasty-quickcheck pkgs.tasty-smallcheck])"
 
   inline-js-test-stack:
     docker:

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Note that both `expr`/`block` supports using `await`, making it convenient to wo
 The `expr`/`block` QuasiQuoters in `inline-js` pass JSON data between Haskell/JavaScript. `inline-js-core` additionally provides ability to:
 
 * Pass raw binary data, or `JSVal`s which are references of arbitrary JavaScript values.
-* Run dynamic `import()` to import a built-in module, npm module in `node_modules`, or a `.mjs` module file.
+* Run `import()` or `require()` to import a built-in module, npm module in `node_modules`, or a `.mjs` module file.
 * Specify evaluate/resolve timeouts when evaluating JavaScript.
 * Decouple the send/receive processes, so it's possible to asynchronously send a batch of requests and later retrieve the responses.
 * Exporting a Haskell function as a JavaScript function. It's even possible to make the JavaScript function *synchronous* so it can be used as a WebAssembly import!

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Important note: do not run untrusted JavaScript via `inline-js-core`/`inline-js`
 
 Simply `stack build` shall do. Run `stack test inline-js` to run the test suite, `stack test inline-js --test-arguments="-j8"` for parallel testing. `cabal new-build` should also work.
 
-`inline-js-core`/`inline-js` requires at least nodejs 11 to work; earlier versions will be rejected upon initialization of `JSSession`.
+`inline-js-core`/`inline-js` requires at least nodejs 12.2 to work; earlier versions will be rejected upon initialization of `JSSession`.
 
 ## Sponsors
 

--- a/inline-js-core/jsbits/context.mjs
+++ b/inline-js-core/jsbits/context.mjs
@@ -1,5 +1,0 @@
-import JSVal from "./jsval.mjs";
-
-global.JSVal = JSVal;
-
-export default global;

--- a/inline-js-core/jsbits/eval.mjs
+++ b/inline-js-core/jsbits/eval.mjs
@@ -1,3 +1,4 @@
+import module from "module";
 import path from "path";
 import process from "process";
 import { StringDecoder } from "string_decoder";
@@ -62,6 +63,7 @@ function callHSFuncRequestBody(hs_func_ref, args) {
 }
 
 global.JSVal = JSVal;
+global.require = module.createRequire(import.meta.url);
 
 ipc.on("message", async ([msg_id, msg_tag, buf]) => {
   try {

--- a/inline-js-core/jsbits/eval.mjs
+++ b/inline-js-core/jsbits/eval.mjs
@@ -4,16 +4,23 @@ import { StringDecoder } from "string_decoder";
 import url from "url";
 import vm from "vm";
 import { Worker } from "worker_threads";
+import JSVal from "./jsval.mjs";
 
-import context_global from "./context.mjs";
+function errorStringify(err) {
+  return err.stack ? err.stack : `${err}`;
+}
 
 process.on("uncaughtException", err => {
-  process.stderr.write(err.stack);
+  process.stderr.write(errorStringify(err));
   throw err;
 });
 
-const ctx = vm.createContext(context_global),
-  decoder = new StringDecoder("utf8"),
+process.on("unhandledRejection", err => {
+  process.stderr.write(errorStringify(err));
+  throw err;
+});
+
+const decoder = new StringDecoder("utf8"),
   shared_futex = new Int32Array(new SharedArrayBuffer(4)),
   shared_flag = new Int32Array(new SharedArrayBuffer(4)),
   shared_msg_len = new Int32Array(new SharedArrayBuffer(4)),
@@ -54,6 +61,8 @@ function callHSFuncRequestBody(hs_func_ref, args) {
   return Buffer.concat(buf_args);
 }
 
+global.JSVal = JSVal;
+
 ipc.on("message", async ([msg_id, msg_tag, buf]) => {
   try {
     buf = Buffer.from(buf);
@@ -68,7 +77,7 @@ ipc.on("message", async ([msg_id, msg_tag, buf]) => {
             importModuleDynamically: spec => import(spec)
           };
         if (eval_timeout) eval_options.timeout = eval_timeout;
-        const eval_result = vm.runInContext(msg_content, ctx, eval_options),
+        const eval_result = vm.runInThisContext(msg_content, eval_options),
           raw_promise = Promise.resolve(
             eval_result === undefined ? null : eval_result
           ),
@@ -85,7 +94,7 @@ ipc.on("message", async ([msg_id, msg_tag, buf]) => {
           msg_id,
           false,
           ret_tag === 1
-            ? bufferFromU32(ctx.JSVal.newJSVal(promise_result))
+            ? bufferFromU32(JSVal.newJSVal(promise_result))
             : ret_tag === 2
             ? Buffer.allocUnsafe(0)
             : promise_result
@@ -93,11 +102,7 @@ ipc.on("message", async ([msg_id, msg_tag, buf]) => {
         break;
       }
       case 1: {
-        ipc.postMessage([
-          msg_id,
-          false,
-          bufferFromU32(ctx.JSVal.newJSVal(buf))
-        ]);
+        ipc.postMessage([msg_id, false, bufferFromU32(JSVal.newJSVal(buf))]);
         break;
       }
       case 3: {
@@ -106,10 +111,10 @@ ipc.on("message", async ([msg_id, msg_tag, buf]) => {
           msg_id,
           false,
           bufferFromU32(
-            ctx.JSVal.newJSVal(
+            JSVal.newJSVal(
               (...args) =>
                 new Promise((resolve, reject) => {
-                  const callback_id = ctx.JSVal.newJSVal([resolve, reject]);
+                  const callback_id = JSVal.newJSVal([resolve, reject]);
                   ipc.postMessage([
                     callback_id,
                     false,
@@ -122,7 +127,7 @@ ipc.on("message", async ([msg_id, msg_tag, buf]) => {
         break;
       }
       case 4: {
-        const [resolve, reject] = ctx.JSVal.takeJSVal(msg_id),
+        const [resolve, reject] = JSVal.takeJSVal(msg_id),
           is_err = Boolean(buf.readUInt32LE(0)),
           hs_result = buf.slice(4);
         (is_err ? reject : resolve)(hs_result);
@@ -134,7 +139,7 @@ ipc.on("message", async ([msg_id, msg_tag, buf]) => {
           msg_id,
           false,
           bufferFromU32(
-            ctx.JSVal.newJSVal((...args) => {
+            JSVal.newJSVal((...args) => {
               Atomics.store(shared_futex, 0, 0);
               ipc.postMessage([
                 0,
@@ -162,6 +167,6 @@ ipc.on("message", async ([msg_id, msg_tag, buf]) => {
       }
     }
   } catch (err) {
-    ipc.postMessage([msg_id, true, err.stack ? err.stack : err.toString()]);
+    ipc.postMessage([msg_id, true, errorStringify(err)]);
   }
 });

--- a/inline-js-core/src/Language/JavaScript/Inline/Core/NodeVersion.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Core/NodeVersion.hs
@@ -34,5 +34,8 @@ nodeVersion p = do
 checkNodeVersion :: FilePath -> IO ()
 checkNodeVersion p = do
   v <- nodeVersion p
-  unless (v >= Version [11] []) $
-    fail $ "Detected node version " <> show v <> ", requires at least node 11"
+  unless (v >= Version [12, 2] [])
+    $ fail
+    $ "Detected node version "
+    <> show v
+    <> ", requires at least node 12.2"

--- a/inline-js/inline-js.cabal
+++ b/inline-js/inline-js.cabal
@@ -70,7 +70,7 @@ test-suite inline-js-test-suite
     , process
     , smallcheck
     , tasty
-    , tasty-hspec
+    , tasty-hunit
     , tasty-quickcheck
     , tasty-smallcheck
   default-language: Haskell2010

--- a/inline-js/tests/Tests/Evaluation.hs
+++ b/inline-js/tests/Tests/Evaluation.hs
@@ -31,6 +31,7 @@ tests =
                 [ ( eval s "import('fs').then(fs => fs.readFileSync.toString())",
                     notError
                     ),
+                  (eval s "require('process').version", notError),
                   (evalWithTimeout s (Just 1000) Nothing "while(true){}", isError),
                   (eval s "BOOM", isError),
                   ( eval s "let x = 6*7; JSON.stringify(null)",

--- a/inline-js/tests/Tests/Evaluation.hs
+++ b/inline-js/tests/Tests/Evaluation.hs
@@ -1,53 +1,69 @@
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
 
 module Tests.Evaluation
   ( tests
   ) where
 
+import Control.Exception
 import Data.Aeson
 import qualified Data.ByteString.Lazy as LBS
 import Data.Foldable
 import Data.Functor
 import Language.JavaScript.Inline.Core
-import Test.Tasty (TestTree)
-import Test.Tasty.Hspec
+import Test.Tasty
+import Test.Tasty.HUnit
 
 tests :: IO TestTree
 tests =
-  testSpec "JSCode Evaluation" $
-  it "Should Handle Many Mixed-Async-and-Sync Requests" $
-  withJSSession defJSSessionOpts $ \s -> do
-    let testPair :: (IO LBS.ByteString, IO LBS.ByteString -> IO ()) -> IO ()
-        testPair (c, f) = f c
-    traverse_
-      testPair
-      [ (eval s "import('fs').then(fs => fs.readFileSync.toString())", notError)
-      , (evalWithTimeout s (Just 1000) Nothing "while(true){}", isError)
-      , (eval s "BOOM", isError)
-      , (eval s "let x = 6*7; JSON.stringify(null)", successfullyReturns Null)
-      , (eval s "JSON.stringify(x)", successfullyReturns $ Number 42)
-      , ( eval s "JSON.stringify(\"left\" + \"pad\")"
-        , successfullyReturns $ String "leftpad")
-      , (eval s "Promise.reject('BOOM')", isError)
-      , ( eval s "Promise.resolve(JSON.stringify(x))"
-        , successfullyReturns $ Number 42)
-      , ( evalWithTimeout
-            s
-            Nothing
-            (Just 1000)
-            "new Promise((resolve, _) => setTimeout(resolve, 10000))"
-        , isError)
-      ]
+  pure
+    $ testGroup
+        "JSCode Evaluation"
+        [ testCase "Should Handle Many Mixed-Async-and-Sync Requests"
+            $ withJSSession defJSSessionOpts
+            $ \s -> do
+              let testPair :: (IO LBS.ByteString, IO LBS.ByteString -> IO ()) -> IO ()
+                  testPair (c, f) = f c
+              traverse_
+                testPair
+                [ ( eval s "import('fs').then(fs => fs.readFileSync.toString())",
+                    notError
+                    ),
+                  (evalWithTimeout s (Just 1000) Nothing "while(true){}", isError),
+                  (eval s "BOOM", isError),
+                  ( eval s "let x = 6*7; JSON.stringify(null)",
+                    successfullyReturns Null
+                    ),
+                  (eval s "JSON.stringify(x)", successfullyReturns $ Number 42),
+                  ( eval s "JSON.stringify(\"left\" + \"pad\")",
+                    successfullyReturns $ String "leftpad"
+                    ),
+                  (eval s "Promise.reject('BOOM')", isError),
+                  ( eval s "Promise.resolve(JSON.stringify(x))",
+                    successfullyReturns $ Number 42
+                    ),
+                  ( evalWithTimeout
+                      s
+                      Nothing
+                      (Just 1000)
+                      "new Promise((resolve, _) => setTimeout(resolve, 10000))",
+                    isError
+                    )
+                  ]
+          ]
 
 successfullyReturns :: Value -> IO LBS.ByteString -> IO ()
 successfullyReturns expected c = do
   r <- c
-  decode' r `shouldBe` Just expected
+  decode' r @?= Just expected
 
 isError, notError :: IO a -> IO ()
-isError = (`shouldThrow` anyException)
+isError m = do
+  r <- try m
+  case r of
+    Left (_ :: SomeException) -> pure ()
+    Right _ -> fail "isError: not an error"
 
 notError = void

--- a/inline-js/tests/Tests/LeftPad.hs
+++ b/inline-js/tests/Tests/LeftPad.hs
@@ -11,20 +11,28 @@ import Language.JavaScript.Inline.Core
 import System.Directory
 import System.Process
 import Test.Tasty
-import Test.Tasty.Hspec
+import Test.Tasty.HUnit
 
 tests :: IO TestTree
 tests =
-  testSpec "left-pad" $
-  it "should install left-pad from npm and run it" $ do
-    tmpdir <- getTemporaryDirectory
-    x <-
-      withTempDirectory silent tmpdir "inline-js-test-suite-left-pad" $ \p -> do
-        _ <-
-          readCreateProcess
-            ((shell "npm install left-pad") {cwd = Just p, std_err = CreatePipe})
-            ""
-        withJSSession defJSSessionOpts {nodeWorkDir = Just p} $ \s -> do
-          mref <- eval s "import('left-pad').then(m => m.default)"
-          eval s $ deRefJSVal mref <> "('foo', 5)"
-    x `shouldBe` ("  foo" :: LBS.ByteString)
+  pure
+    $ testGroup
+        "left-pad"
+        [ testCase "should install left-pad from npm and run it" $ do
+            tmpdir <- getTemporaryDirectory
+            x <-
+              withTempDirectory silent tmpdir "inline-js-test-suite-left-pad" $ \p ->
+                do
+                  _ <-
+                    readCreateProcess
+                      ( (shell "npm install left-pad")
+                          { cwd = Just p,
+                            std_err = CreatePipe
+                            }
+                        )
+                      ""
+                  withJSSession defJSSessionOpts {nodeWorkDir = Just p} $ \s -> do
+                    mref <- eval s "import('left-pad').then(m => m.default)"
+                    eval s $ deRefJSVal mref <> "('foo', 5)"
+            x @?= ("  foo" :: LBS.ByteString)
+          ]

--- a/inline-js/tests/Tests/Quotation.hs
+++ b/inline-js/tests/Tests/Quotation.hs
@@ -14,8 +14,8 @@ import qualified Data.ByteString.Lazy.Char8 as LBS
 import Data.Text (pack)
 import GHC.Generics (Generic)
 import Language.JavaScript.Inline
-import Test.Tasty (TestTree)
-import Test.Tasty.Hspec (it, shouldBe, testSpec)
+import Test.Tasty
+import Test.Tasty.HUnit
 
 -- Datatypes used by tests
 newtype GameWorld = GameWorld
@@ -31,82 +31,87 @@ data PlayerCharacter = PlayerCharacter
 -- A test of the initial implementation, with manual Value conversion
 tests :: IO TestTree
 tests =
-  testSpec "Inline JavaScript QuasiQuoter" $ do
-    it "should add two numbers and return a Number" $ do
-      result <- withJSSession defJSSessionOpts [expr| 1 + 3 |]
-      result `shouldBe` (4 :: Int)
-    it "should concatenate two Strings" $ do
-      result <- withJSSession defJSSessionOpts [expr| "hello" + " goodbye" |]
-      result `shouldBe` "hello goodbye"
-    it "should take in a Haskell String and return it" $ do
-      let sentence = "This is a String"
-      result <- withJSSession defJSSessionOpts [expr| $sentence |]
-      result `shouldBe` sentence
-    it "should append a Haskell-inserted String to a JavaScript String" $ do
-      let sentence = "Pineapple"
-      result <- withJSSession defJSSessionOpts [expr| $sentence + " on pizza" |]
-      result `shouldBe` "Pineapple on pizza"
-    it "should work when reusing the same variable in the same splice" $ do
-      let myNumber = 4 :: Int
-      result <- withJSSession defJSSessionOpts [expr| $myNumber + $myNumber |]
-      result `shouldBe` (8 :: Int)
-    it "should compute the result of three separate variables" $ do
-      let firstNumber = 1 :: Int
-          secondNumber = 2 :: Int
-          thirdNumber = 9 :: Int
-      result <-
-        withJSSession
-          defJSSessionOpts
-          [expr| $firstNumber + $secondNumber + $thirdNumber |]
-      result `shouldBe` (12 :: Int)
-    it "should not share state when reusing the same variable across splices" $ do
-      let myNumber = 3 :: Int
-      result1 <- withJSSession defJSSessionOpts [expr| $myNumber + 3 |]
-      result2 <- withJSSession defJSSessionOpts [expr| $myNumber + 4 |]
-      result1 `shouldBe` (6 :: Int)
-      result2 `shouldBe` (7 :: Int)
-    it
-      "should not share state when resuing the same variable name across splices" $ do
-      let firstOperation =
-            let word = pack "Bananas"
-             in do result <- withJSSession defJSSessionOpts [expr| $word |]
-                   result `shouldBe` word
-      let secondOperation =
-            let word = pack "Pears"
-             in do result <- withJSSession defJSSessionOpts [expr| $word |]
-                   result `shouldBe` word
-      firstOperation
-      secondOperation
-      firstOperation
-    it
-      "should not collide names when reusing the same variable name across splices in the same session" $ do
-      session <- newJSSession defJSSessionOpts
-      forM_ [1 :: Int .. 10] $
-        const $ do
-          let word = pack "Bananas"
-          result <- [expr| $word |] session
-          result `shouldBe` word
-      closeJSSession session
-    it "should process a simple block expression" $ do
-      let myNumber = 3 :: Int
-      result <-
-        withJSSession
-          defJSSessionOpts
-          [block|
+  pure
+    $ testGroup
+        "Inline JavaScript QuasiQuoter"
+        [ testCase "should add two numbers and return a Number" $ do
+            result <- withJSSession defJSSessionOpts [expr| 1 + 3 |]
+            result @?= (4 :: Int),
+          testCase "should concatenate two Strings" $ do
+            result <- withJSSession defJSSessionOpts [expr| "hello" + " goodbye" |]
+            result @?= "hello goodbye",
+          testCase "should take in a Haskell String and return it" $ do
+            let sentence = "This is a String"
+            result <- withJSSession defJSSessionOpts [expr| $sentence |]
+            result @?= sentence,
+          testCase "should append a Haskell-inserted String to a JavaScript String" $ do
+            let sentence = "Pineapple"
+            result <-
+              withJSSession defJSSessionOpts [expr| $sentence + " on pizza" |]
+            result @?= "Pineapple on pizza",
+          testCase "should work when reusing the same variable in the same splice" $ do
+            let myNumber = 4 :: Int
+            result <- withJSSession defJSSessionOpts [expr| $myNumber + $myNumber |]
+            result @?= (8 :: Int),
+          testCase "should compute the result of three separate variables" $ do
+            let firstNumber = 1 :: Int
+                secondNumber = 2 :: Int
+                thirdNumber = 9 :: Int
+            result <-
+              withJSSession
+                defJSSessionOpts
+                [expr| $firstNumber + $secondNumber + $thirdNumber |]
+            result @?= (12 :: Int),
+          testCase
+            "should not share state when reusing the same variable across splices" $ do
+            let myNumber = 3 :: Int
+            result1 <- withJSSession defJSSessionOpts [expr| $myNumber + 3 |]
+            result2 <- withJSSession defJSSessionOpts [expr| $myNumber + 4 |]
+            result1 @?= (6 :: Int)
+            result2 @?= (7 :: Int),
+          testCase
+            "should not share state when resuing the same variable name across splices" $ do
+            let firstOperation =
+                  let word = pack "Bananas"
+                   in do
+                        result <- withJSSession defJSSessionOpts [expr| $word |]
+                        result @?= word
+            let secondOperation =
+                  let word = pack "Pears"
+                   in do
+                        result <- withJSSession defJSSessionOpts [expr| $word |]
+                        result @?= word
+            firstOperation
+            secondOperation
+            firstOperation,
+          testCase
+            "should not collide names when reusing the same variable name across splices in the same session" $ do
+            session <- newJSSession defJSSessionOpts
+            forM_ [1 :: Int .. 10]
+              $ const $ do
+              let word = pack "Bananas"
+              result <- [expr| $word |] session
+              result @?= word
+            closeJSSession session,
+          testCase "should process a simple block expression" $ do
+            let myNumber = 3 :: Int
+            result <-
+              withJSSession
+                defJSSessionOpts
+                [block|
             const myNumber = $myNumber;
             return "Your number was: " + myNumber;
           |]
-      result `shouldBe` pack "Your number was: 3"
-    it "should process a complex block expression" $ do
-      let gameWorld =
-            GameWorld
-              { playerCharacter =
-                  PlayerCharacter {hp = 10, maxHp = 30, isDead = False}
-              }
-      result <-
-        withJSSession
-          defJSSessionOpts
-          [block|
+            result @?= pack "Your number was: 3",
+          testCase "should process a complex block expression" $ do
+            let gameWorld =
+                  GameWorld
+                    { playerCharacter = PlayerCharacter {hp = 10, maxHp = 30, isDead = False}
+                      }
+            result <-
+              withJSSession
+                defJSSessionOpts
+                [block|
             const gameWorld = $gameWorld;
             const player = gameWorld.playerCharacter;
             const renderHp = somePlayer => somePlayer.hp + "/" + somePlayer.maxHp;
@@ -116,12 +121,13 @@ tests =
               return "Your HP: " + renderHp(player);
             }
           |]
-      result `shouldBe` "Your HP: 10/30"
-    it "should pass and return a lazy ByteString" $ do
-      let buf = LBS.pack "SPICE GIRL WANNABEEE"
-      result <-
-        withJSSession defJSSessionOpts $ \s -> do
-          () <- [expr| global.x = $buf |] s
-          (v :: JSVal) <- [expr| global.x |] s
-          [expr| $v |] s
-      result `shouldBe` buf
+            result @?= "Your HP: 10/30",
+          testCase "should pass and return a lazy ByteString" $ do
+            let buf = LBS.pack "SPICE GIRL WANNABEEE"
+            result <-
+              withJSSession defJSSessionOpts $ \s -> do
+                () <- [expr| global.x = $buf |] s
+                (v :: JSVal) <- [expr| global.x |] s
+                [expr| $v |] s
+            result @?= buf
+          ]

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-13.28
+resolver: lts-14.2
 packages:
   - inline-js
   - inline-js-core


### PR DESCRIPTION
* Add preliminary support for `require()`
* Bump minimal required node version to `12.2`
* Set up the unresolved promise rejection handler in `eval.mjs`
* Switch from `tasty-hspec` to `tasty-hunit` for all tests
* Bump stackage resolver & nixpkgs revision
* Fix CI due to losing access to resource classes