### PR TITLE
Apply `ormolu` to existing Haskell codebase

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,6 +77,8 @@ jobs:
             brew install \
               haskell-stack \
               node
+            node --version
+            npm --version
       - checkout
       - run:
           name: Test inline-js

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
           command: |
             apt update
             apt full-upgrade -y
-            nix-channel --add https://releases.nixos.org/nixpkgs/nixpkgs-20.03pre193309.c4196cca9ac nixpkgs
+            nix-channel --add https://releases.nixos.org/nixpkgs/nixpkgs-20.03pre194957.bef773ed53f nixpkgs
             nix-channel --update
             nix-env -u
             nix-env -iA \
@@ -38,7 +38,7 @@ jobs:
       - run:
           name: Install dependencies
           command: |
-            nix-channel --add https://releases.nixos.org/nixpkgs/nixpkgs-20.03pre193309.c4196cca9ac nixpkgs
+            nix-channel --add https://releases.nixos.org/nixpkgs/nixpkgs-20.03pre194957.bef773ed53f nixpkgs
             nix-channel --update
             nix-env -u
             nix-env -iA \
@@ -62,7 +62,7 @@ jobs:
       - run:
           name: Install dependencies
           command: |
-            nix-channel --add https://releases.nixos.org/nixpkgs/nixpkgs-20.03pre193309.c4196cca9ac nixpkgs
+            nix-channel --add https://releases.nixos.org/nixpkgs/nixpkgs-20.03pre194957.bef773ed53f nixpkgs
             nix-channel --update
             nix-env -u
             nix-env -iA \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
           name: Install dependencies
           command: |
             curl -sSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
-            echo "deb https://deb.nodesource.com/node_12.x sid main" > /etc/apt/sources.list.d/nodesource.list
+            echo "deb https://deb.nodesource.com/node_12.x disco main" > /etc/apt/sources.list.d/nodesource.list
             apt update
             apt full-upgrade -y
             apt install -y nodejs
@@ -30,7 +30,7 @@ jobs:
           name: Install dependencies
           command: |
             curl -sSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
-            echo "deb https://deb.nodesource.com/node_13.x sid main" > /etc/apt/sources.list.d/nodesource.list
+            echo "deb https://deb.nodesource.com/node_13.x disco main" > /etc/apt/sources.list.d/nodesource.list
             apt update
             apt full-upgrade -y
             apt install -y nodejs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
       - run:
           name: Test inline-js
           command: |
-            stack --no-terminal build --haddock --test --no-run-tests
+            stack --no-terminal -j2 build --haddock --test --no-run-tests
             stack --no-terminal test inline-js --test-arguments="-j2"
 
   inline-js-test-nodejs-13:
@@ -40,7 +40,7 @@ jobs:
       - run:
           name: Test inline-js
           command: |
-            stack --no-terminal build --haddock --test --no-run-tests
+            stack --no-terminal -j2 build --haddock --test --no-run-tests
             stack --no-terminal test inline-js --test-arguments="-j2"
 
   inline-js-test-nodejs-v8:
@@ -62,7 +62,7 @@ jobs:
       - run:
           name: Test inline-js
           command: |
-            stack --no-terminal build --haddock --test --no-run-tests
+            stack --no-terminal -j2 build --haddock --test --no-run-tests
             stack --no-terminal test inline-js --test-arguments="-j2"
 
   inline-js-test-macos:
@@ -81,8 +81,8 @@ jobs:
       - run:
           name: Test inline-js
           command: |
-            stack --no-terminal build --test --no-run-tests
-            stack --no-terminal test inline-js --test-arguments="-j2"
+            stack --no-terminal -j4 build --test --no-run-tests
+            stack --no-terminal test inline-js --test-arguments="-j4"
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,85 +1,94 @@
 version: 2
 
 jobs:
-  inline-js-test-nix-nodejs-v8:
+  inline-js-test-nodejs-12:
     docker:
-      - image: terrorjack/pixie:debian
+      - image: terrorjack/stackage:lts-14.11
+    steps:
+      - run:
+          name: Install dependencies
+          command: |
+            curl -sSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
+            echo "deb https://deb.nodesource.com/node_12.x sid main" > /etc/apt/sources.list.d/nodesource.list
+            apt update
+            apt full-upgrade -y
+            apt install -y nodejs
+            node --version
+            npm --version
+      - checkout
+      - run:
+          name: Test inline-js
+          command: |
+            stack --no-terminal build --haddock --test --no-run-tests
+            stack --no-terminal test inline-js --test-arguments="-j2"
+
+  inline-js-test-nodejs-13:
+    docker:
+      - image: terrorjack/stackage:lts-14.11
+    steps:
+      - run:
+          name: Install dependencies
+          command: |
+            curl -sSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
+            echo "deb https://deb.nodesource.com/node_13.x sid main" > /etc/apt/sources.list.d/nodesource.list
+            apt update
+            apt full-upgrade -y
+            apt install -y nodejs
+            node --version
+            npm --version
+      - checkout
+      - run:
+          name: Test inline-js
+          command: |
+            stack --no-terminal build --haddock --test --no-run-tests
+            stack --no-terminal test inline-js --test-arguments="-j2"
+
+  inline-js-test-nodejs-v8:
+    docker:
+      - image: terrorjack/stackage:lts-14.11
     steps:
       - run:
           name: Install dependencies
           command: |
             apt update
             apt full-upgrade -y
-            nix-channel --add https://releases.nixos.org/nixpkgs/nixpkgs-20.03pre194957.bef773ed53f nixpkgs
-            nix-channel --update
-            nix-env -u
-            nix-env -iA \
-              nixpkgs.curl \
-              nixpkgs.gitMinimal \
-              nixpkgs.openssh \
-              nixpkgs.python3
             cd /usr
             curl -L https://raw.githubusercontent.com/tweag/asterius/master/utils/v8-node.py | python3
             export npm_config_prefix=/usr
             curl -L https://www.npmjs.com/install.sh | sh
+            node --version
+            npm --version
       - checkout
       - run:
           name: Test inline-js
           command: |
-            nix-shell \
-              --command "cabal new-run -j2 inline-js:inline-js-test-suite -- -j2" \
-              -p cabal-install \
-              -p "haskellPackages.ghcWithPackages (pkgs: [pkgs.aeson pkgs.base64-bytestring pkgs.language-javascript pkgs.tasty-hunit pkgs.tasty-quickcheck pkgs.tasty-smallcheck])"
+            stack --no-terminal build --haddock --test --no-run-tests
+            stack --no-terminal test inline-js --test-arguments="-j2"
 
-  inline-js-test-nix-nodejs-12:
-    docker:
-      - image: terrorjack/pixie:latest
+  inline-js-test-macos:
+    macos:
+      xcode: "11.1.0"
     steps:
       - run:
           name: Install dependencies
           command: |
-            nix-channel --add https://releases.nixos.org/nixpkgs/nixpkgs-20.03pre194957.bef773ed53f nixpkgs
-            nix-channel --update
-            nix-env -u
-            nix-env -iA \
-              nixpkgs.gitMinimal \
-              nixpkgs.openssh
+            brew update
+            brew upgrade
+            brew install \
+              haskell-stack \
+              node
       - checkout
       - run:
           name: Test inline-js
           command: |
-            nix-shell \
-              --command "cabal new-run -j2 inline-js:inline-js-test-suite -- -j2" \
-              --pure \
-              -p cabal-install \
-              -p nodejs-12_x \
-              -p "haskellPackages.ghcWithPackages (pkgs: [pkgs.aeson pkgs.base64-bytestring pkgs.language-javascript pkgs.tasty-hunit pkgs.tasty-quickcheck pkgs.tasty-smallcheck])"
-
-  inline-js-test-stack:
-    docker:
-      - image: terrorjack/pixie:latest
-    steps:
-      - run:
-          name: Install dependencies
-          command: |
-            nix-channel --add https://releases.nixos.org/nixpkgs/nixpkgs-20.03pre194957.bef773ed53f nixpkgs
-            nix-channel --update
-            nix-env -u
-            nix-env -iA \
-              nixpkgs.gitMinimal \
-              nixpkgs.openssh \
-              nixpkgs.stack
-      - checkout
-      - run:
-          name: Test inline-js
-          command: |
-            stack --nix --no-nix-pure --no-terminal build --haddock --test --no-run-tests
-            stack --nix --no-nix-pure --no-terminal test inline-js --test-arguments="-j2"
+            stack --no-terminal build --test --no-run-tests
+            stack --no-terminal test inline-js --test-arguments="-j2"
 
 workflows:
   version: 2
   build:
     jobs:
-      - inline-js-test-nix-nodejs-v8
-      - inline-js-test-nix-nodejs-12
-      - inline-js-test-stack
+      - inline-js-test-nodejs-12
+      - inline-js-test-nodejs-13
+      - inline-js-test-nodejs-v8
+      - inline-js-test-macos

--- a/inline-js-core/src/Language/JavaScript/Inline/Core.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Core.hs
@@ -1,38 +1,41 @@
 module Language.JavaScript.Inline.Core
-  ( JSSessionOpts(..)
-  , defJSSessionOpts
-  , JSSession
-  , newJSSession
-  , closeJSSession
-  , withJSSession
-  , nodeStdIn
-  , nodeStdOut
-  , nodeStdErr
-  , JSCode(..)
-  , bufferToString
-  , jsonParse
-  , jsonStringify
-  , JSVal(..)
-  , deRefJSVal
-  , freeJSVal
-  , takeJSVal
-  , HSFunc(..)
-  , EvalException(..)
-  , eval
-  , evalWithTimeout
-  , alloc
-  , importMJS
-  , exportHSFunc
-  , exportSyncHSFunc
-  , eval'
-  , evalWithTimeout'
-  , alloc'
-  , importMJS'
-  , exportHSFunc'
-  , exportSyncHSFunc'
-  ) where
+  ( JSSessionOpts (..),
+    defJSSessionOpts,
+    JSSession,
+    newJSSession,
+    closeJSSession,
+    withJSSession,
+    nodeStdIn,
+    nodeStdOut,
+    nodeStdErr,
+    JSCode (..),
+    bufferToString,
+    jsonParse,
+    jsonStringify,
+    JSVal (..),
+    deRefJSVal,
+    freeJSVal,
+    takeJSVal,
+    HSFunc (..),
+    EvalException (..),
+    eval,
+    evalWithTimeout,
+    alloc,
+    importMJS,
+    exportHSFunc,
+    exportSyncHSFunc,
+    eval',
+    evalWithTimeout',
+    alloc',
+    importMJS',
+    exportHSFunc',
+    exportSyncHSFunc',
+  )
+where
 
 import Language.JavaScript.Inline.Core.Command
 import Language.JavaScript.Inline.Core.HSCode
-import Language.JavaScript.Inline.Core.JSCode hiding (importMJS)
+import Language.JavaScript.Inline.Core.JSCode hiding
+  ( importMJS,
+  )
 import Language.JavaScript.Inline.Core.Session

--- a/inline-js-core/src/Language/JavaScript/Inline/Core/Command.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Core/Command.hs
@@ -4,133 +4,138 @@
 {-# LANGUAGE TypeFamilies #-}
 
 module Language.JavaScript.Inline.Core.Command
-  ( EvalException(..)
-  , eval
-  , eval'
-  , evalWithTimeout
-  , evalWithTimeout'
-  , alloc
-  , alloc'
-  , importMJS
-  , importMJS'
-  , exportHSFunc
-  , exportHSFunc'
-  , exportSyncHSFunc
-  , exportSyncHSFunc'
-  ) where
+  ( EvalException (..),
+    eval,
+    eval',
+    evalWithTimeout,
+    evalWithTimeout',
+    alloc,
+    alloc',
+    importMJS,
+    importMJS',
+    exportHSFunc,
+    exportHSFunc',
+    exportSyncHSFunc,
+    exportSyncHSFunc',
+  )
+where
 
 import Control.Exception
 import Control.Monad
 import qualified Data.ByteString.Lazy as LBS
 import Language.JavaScript.Inline.Core.HSCode
-import Language.JavaScript.Inline.Core.JSCode hiding (importMJS)
+import Language.JavaScript.Inline.Core.JSCode hiding
+  ( importMJS,
+  )
 import qualified Language.JavaScript.Inline.Core.JSCode as JSCode
 import Language.JavaScript.Inline.Core.Message.Class
 import Language.JavaScript.Inline.Core.Message.Eval
 import Language.JavaScript.Inline.Core.Session
-import Prelude
 import System.Directory
+import Prelude
 
 -- | The eval server may respond with an error message, in which case this
 -- exception is raised.
-newtype EvalException = EvalException
-  { evalErrorMessage :: LBS.ByteString
-  } deriving (Show)
+newtype EvalException
+  = EvalException
+      { evalErrorMessage :: LBS.ByteString
+      }
+  deriving (Show)
 
 instance Exception EvalException
 
 checkEvalResponse :: EvalResponse r -> IO r
-checkEvalResponse r =
-  case r of
-    EvalError {..} -> throwIO EvalException {evalErrorMessage = evalError}
-    EvalResult {..} -> pure evalResult
+checkEvalResponse r = case r of
+  EvalError {..} -> throwIO EvalException {evalErrorMessage = evalError}
+  EvalResult {..} -> pure evalResult
 
 checkEvalResponse' :: IO (EvalResponse r) -> IO r
 checkEvalResponse' = (>>= checkEvalResponse)
 
--- | Runs a 'JSCode' and returns the result. The 'JSCode' evaluation result
--- is called with @Promise.resolve()@, then we return the resolved value
--- back to Haskell.
+-- | Runs a 'JSCode' and returns the result. The 'JSCode' evaluation result is
+-- called with @Promise.resolve()@, then we return the resolved value back to
+-- Haskell.
 --
 -- Throws in Haskell if the response indicates a failure.
 --
--- Explicit type annotation of the returned value is often required.
--- Supported types are:
+-- Explicit type annotation of the returned value is often required. Supported
+-- types are:
 --
--- 1. @Data.ByteString.Lazy.ByteString@, which indicates the code returns
--- a piece of raw binary data. The data is wrapped by @Buffer.from()@.
+-- 1. @Data.ByteString.Lazy.ByteString@, which indicates the code returns a
+--    piece of raw binary data. The data is wrapped by @Buffer.from()@.
 --
 -- 2. @Language.JavaScript.Inline.Core.JSVal@, which indicates whatever value
--- the code returns is first registered as a @JSCode.JSVal@.
+--    the code returns is first registered as a @JSCode.JSVal@.
 --
--- 3. @()@, which indicates the code doesn't return anything
--- (even if it does, the result is discarded)
+-- 3. @()@, which indicates the code doesn't return anything (even if it does,
+--    the result is discarded)
 eval ::
-     forall r.
-     ( Request (EvalRequest r)
-     , Response (EvalResponse r)
-     , ResponseOf (EvalRequest r) ~ (EvalResponse r)
-     )
-  => JSSession
-  -> JSCode
-  -> IO r
+  forall r.
+  ( Request (EvalRequest r),
+    Response (EvalResponse r),
+    ResponseOf (EvalRequest r) ~ (EvalResponse r)
+  ) =>
+  JSSession ->
+  JSCode ->
+  IO r
 eval s = join . eval' s
 
--- | Asynchronous version of 'eval'.
--- Returns the 'IO' action to actually fetch the result.
--- The returned action blocks if the result is not ready yet.
+-- | Asynchronous version of 'eval'. Returns the 'IO' action to actually fetch
+-- the result. The returned action blocks if the result is not ready yet.
 --
--- The point of exporting async versions of APIs is to allow
--- users to improve concurrency without needing to manually
--- fork lots of threads. When performing batch requests, you can
--- first obtain the 'IO' actions, allow requests to be sent to
--- @node@ to be processed concurrently, and retrieve results later.
+-- The point of exporting async versions of APIs is to allow users to improve
+-- concurrency without needing to manually fork lots of threads. When performing
+-- batch requests, you can first obtain the 'IO' actions, allow requests to be
+-- sent to @node@ to be processed concurrently, and retrieve results later.
 --
--- All returned 'IO' actions are idempotent. And all sync/async
--- APIs are fully thread-safe; although unnecessary, you can still
--- invoke them in whatever forked thread you created :)
+-- All returned 'IO' actions are idempotent. And all sync/async APIs are fully
+-- thread-safe; although unnecessary, you can still invoke them in whatever
+-- forked thread you created :)
 eval' ::
-     forall r.
-     ( Request (EvalRequest r)
-     , Response (EvalResponse r)
-     , ResponseOf (EvalRequest r) ~ (EvalResponse r)
-     )
-  => JSSession
-  -> JSCode
-  -> IO (IO r)
+  forall r.
+  ( Request (EvalRequest r),
+    Response (EvalResponse r),
+    ResponseOf (EvalRequest r) ~ (EvalResponse r)
+  ) =>
+  JSSession ->
+  JSCode ->
+  IO (IO r)
 eval' s = evalWithTimeout' s Nothing Nothing
 
--- | Like 'eval', while the eval/resolve timeouts can be specified
--- in milliseconds.
+-- | Like 'eval', while the eval/resolve timeouts can be specified in
+-- milliseconds.
 evalWithTimeout ::
-     forall r.
-     ( Request (EvalRequest r)
-     , Response (EvalResponse r)
-     , ResponseOf (EvalRequest r) ~ (EvalResponse r)
-     )
-  => JSSession
-  -> Maybe Int
-  -> Maybe Int
-  -> JSCode
-  -> IO r
+  forall r.
+  ( Request (EvalRequest r),
+    Response (EvalResponse r),
+    ResponseOf (EvalRequest r) ~ (EvalResponse r)
+  ) =>
+  JSSession ->
+  Maybe Int ->
+  Maybe Int ->
+  JSCode ->
+  IO r
 evalWithTimeout s et rt c = join $ evalWithTimeout' s et rt c
 
 evalWithTimeout' ::
-     forall r.
-     ( Request (EvalRequest r)
-     , Response (EvalResponse r)
-     , ResponseOf (EvalRequest r) ~ (EvalResponse r)
-     )
-  => JSSession
-  -> Maybe Int
-  -> Maybe Int
-  -> JSCode
-  -> IO (IO r)
+  forall r.
+  ( Request (EvalRequest r),
+    Response (EvalResponse r),
+    ResponseOf (EvalRequest r) ~ (EvalResponse r)
+  ) =>
+  JSSession ->
+  Maybe Int ->
+  Maybe Int ->
+  JSCode ->
+  IO (IO r)
 evalWithTimeout' s et rt c =
-  checkEvalResponse' <$>
-  sendMsg
-    s
-    (EvalRequest {evalTimeout = et, resolveTimeout = rt, evalCode = c} :: EvalRequest r)
+  checkEvalResponse'
+    <$> sendMsg
+      s
+      ( EvalRequest {evalTimeout = et, resolveTimeout = rt, evalCode = c} ::
+          EvalRequest
+            r
+      )
 
 -- | Allocates a @Buffer@ and returns the 'JSVal'.
 --
@@ -142,11 +147,10 @@ alloc' :: JSSession -> LBS.ByteString -> IO (IO JSVal)
 alloc' s buf =
   checkEvalResponse' <$> sendMsg s AllocRequest {allocContent = buf}
 
--- | @import()@ a @.mjs@ ECMAScript module on the local file system,
--- and returns the 'JSVal' of the module namespace object.
--- It's safe to use a relative path here
--- (relative to the Haskell process, not @node@),
--- since we call 'canonicalizePath' first anyway.
+-- | @import()@ a @.mjs@ ECMAScript module on the local file system, and returns
+-- the 'JSVal' of the module namespace object. It's safe to use a relative path
+-- here (relative to the Haskell process, not @node@), since we call
+-- 'canonicalizePath' first anyway.
 --
 -- Throws in Haskell if the response indicates a failure.
 importMJS :: JSSession -> FilePath -> IO JSVal
@@ -157,11 +161,11 @@ importMJS' s p = do
   p' <- canonicalizePath p
   eval' s $ JSCode.importMJS p'
 
--- | Exports an 'HSFunc' to JavaScript,
--- returns the JavaScript wrapper function's 'JSVal' and a finalizer to free the 'HSFunc'.
--- When the 'HSFunc' is no longer used,
--- first call 'freeJSVal' to free the JavaScript wrapper function,
--- then call the finalizer to remove the registered 'HSFunc' from the current 'JSSession'.
+-- | Exports an 'HSFunc' to JavaScript, returns the JavaScript wrapper
+-- function's 'JSVal' and a finalizer to free the 'HSFunc'. When the 'HSFunc' is
+-- no longer used, first call 'freeJSVal' to free the JavaScript wrapper
+-- function, then call the finalizer to remove the registered 'HSFunc' from the
+-- current 'JSSession'.
 --
 -- Throws in Haskell if the response indicates a failure.
 exportHSFunc :: JSSession -> HSFunc -> IO (JSVal, IO ())
@@ -177,8 +181,8 @@ exportHSFunc' s f = do
   pure (c, fin)
 
 -- | Like 'exportHSFunc', except the JavaScript function is made synchronous.
--- Very heavy hammer, only use as a last resort,
--- and make sure the result's length doesn't exceed 'nodeSharedMemSize'.
+-- Very heavy hammer, only use as a last resort, and make sure the result's
+-- length doesn't exceed 'nodeSharedMemSize'.
 exportSyncHSFunc :: JSSession -> HSFunc -> IO (JSVal, IO ())
 exportSyncHSFunc s f = do
   (c, fin) <- exportSyncHSFunc' s f

--- a/inline-js-core/src/Language/JavaScript/Inline/Core/HSCode.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Core/HSCode.hs
@@ -1,28 +1,30 @@
 module Language.JavaScript.Inline.Core.HSCode
-  ( HSFunc(..)
-  , HSFuncRef(..)
-  ) where
+  ( HSFunc (..),
+    HSFuncRef (..),
+  )
+where
 
 import qualified Data.ByteString.Lazy as LBS
 
--- | The type of Haskell functions which can be exported to JavaScript.
--- When invoked, the JavaScript wrapper function sends back the argument list;
--- each argument is converted to binary with @Buffer.from()@.
--- The Haskell function computes and returns the result in a forked thread.
+-- | The type of Haskell functions which can be exported to JavaScript. When
+-- invoked, the JavaScript wrapper function sends back the argument list; each
+-- argument is converted to binary with @Buffer.from()@. The Haskell function
+-- computes and returns the result in a forked thread.
 --
--- Note that the JavaScript wrapper is an async function by default, and returns a
--- @Promise@ which either resolves with a @Buffer@ result,
--- or rejects with an UTF-8 encoded Haskell exception.
+-- Note that the JavaScript wrapper is an async function by default, and returns
+-- a @Promise@ which either resolves with a @Buffer@ result, or rejects with an
+-- UTF-8 encoded Haskell exception.
 --
--- It's possible to export Haskell functions with more fanciful types;
--- one just needs to manually supply wrappers on both the Haskell/JavaScript end
--- to perform serialization/deserialization.
+-- It's possible to export Haskell functions with more fanciful types; one just
+-- needs to manually supply wrappers on both the Haskell/JavaScript end to
+-- perform serialization/deserialization.
 --
--- Note: I tried very hard to introduce a nice type-directed export mechanism here,
--- but gave up upon too many died brain cells :(
-newtype HSFunc = HSFunc
-  { runHSFunc :: [LBS.ByteString] -> IO LBS.ByteString
-  }
+-- Note: I tried very hard to introduce a nice type-directed export mechanism
+-- here, but gave up upon too many died brain cells :(
+newtype HSFunc
+  = HSFunc
+      { runHSFunc :: [LBS.ByteString] -> IO LBS.ByteString
+      }
 
-newtype HSFuncRef =
-  HSFuncRef Int
+newtype HSFuncRef
+  = HSFuncRef Int

--- a/inline-js-core/src/Language/JavaScript/Inline/Core/Internal.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Core/Internal.hs
@@ -1,11 +1,12 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Language.JavaScript.Inline.Core.Internal
-  ( peekHandle
-  , hGetLBS
-  , tryAny
-  , once
-  ) where
+  ( peekHandle,
+    hGetLBS,
+    tryAny,
+    once,
+  )
+where
 
 import Control.Exception
 import Control.Monad
@@ -18,18 +19,18 @@ import System.IO.Unsafe
 hGet' :: Handle -> Ptr a -> Int -> IO ()
 hGet' h p l = do
   l' <- hGetBuf h p l
-  unless (l' == l) $
-    fail $ "hGet': expected " <> show l <> " bytes, got " <> show l'
+  unless (l' == l)
+    $ fail
+    $ "hGet': expected "
+      <> show l
+      <> " bytes, got "
+      <> show l'
 
 {-# INLINE peekHandle #-}
-peekHandle ::
-     forall a. Storable a
-  => Handle
-  -> IO a
-peekHandle h =
-  alloca $ \p -> do
-    hGet' h p (sizeOf (undefined :: a))
-    peek p
+peekHandle :: forall a. Storable a => Handle -> IO a
+peekHandle h = alloca $ \p -> do
+  hGet' h p (sizeOf (undefined :: a))
+  peek p
 
 {-# INLINE hGetLBS #-}
 hGetLBS :: Handle -> Int -> IO LBS.ByteString

--- a/inline-js-core/src/Language/JavaScript/Inline/Core/JSCode.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Core/JSCode.hs
@@ -2,29 +2,30 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 module Language.JavaScript.Inline.Core.JSCode
-  ( JSCode(..)
-  , bufferToString
-  , jsonParse
-  , jsonStringify
-  , importMJS
-  , JSVal(..)
-  , deRefJSVal
-  , freeJSVal
-  , takeJSVal
-  ) where
+  ( JSCode (..),
+    bufferToString,
+    jsonParse,
+    jsonStringify,
+    importMJS,
+    JSVal (..),
+    deRefJSVal,
+    freeJSVal,
+    takeJSVal,
+  )
+where
 
 import Data.ByteString.Builder
 import Data.Coerce
-import Data.String (IsString(..))
+import Data.String (IsString (..))
 
--- | A UTF-8 encoded JavaScript code snippet.
--- Can be a single expression or a series of statements.
+-- | A UTF-8 encoded JavaScript code snippet. Can be a single expression or a
+-- series of statements.
 --
--- Larger expressions can be easily composed from smaller ones
--- by concating 'JSCode', and occasionally adding brackets to
--- ensure valid syntax (e.g. @(f)(a)@ when @f@ is a function expression).
-newtype JSCode =
-  JSCode Builder
+-- Larger expressions can be easily composed from smaller ones by concating
+-- 'JSCode', and occasionally adding brackets to ensure valid syntax (e.g.
+-- @(f)(a)@ when @f@ is a function expression).
+newtype JSCode
+  = JSCode Builder
   deriving (IsString, Semigroup, Monoid)
 
 instance Show JSCode where
@@ -46,21 +47,21 @@ jsonStringify expr = "JSON.stringify(" <> expr <> ")"
 importMJS :: FilePath -> JSCode
 importMJS p =
   coerce $
-  "import('url').then(url => url.pathToFileURL(" <> stringUtf8 (show p) <>
-  ").href).then(url => import(url))"
+    "import('url').then(url => url.pathToFileURL("
+      <> stringUtf8 (show p)
+      <> ").href).then(url => import(url))"
 
 -- | A reference to a JavaScript value.
 --
--- It's supposed to be completely opaque,
--- yet we expose its internal here,
--- so you can use 'JSVal's in stuff like 'Data.IntMap.IntMap'.
+-- It's supposed to be completely opaque, yet we expose its internal here, so
+-- you can use 'JSVal's in stuff like 'Data.IntMap.IntMap'.
 --
--- You can't make a valid 'JSVal' out of thin air.
--- Obtain it either via higher-level TH splices in @inline-js@,
--- or via something like 'Language.JavaScript.Inline.Core.eval',
--- explicitly annotating the return type.
-newtype JSVal =
-  JSVal Int
+-- You can't make a valid 'JSVal' out of thin air. Obtain it either via
+-- higher-level TH splices in @inline-js@, or via something like
+-- 'Language.JavaScript.Inline.Core.eval', explicitly annotating the return
+-- type.
+newtype JSVal
+  = JSVal Int
   deriving (Eq, Ord, Show)
 
 -- | Dereferences a 'JSVal' and returns the value.
@@ -71,7 +72,8 @@ deRefJSVal (JSVal p) = JSCode $ mconcat ["JSVal.deRefJSVal(", intDec p, ")"]
 
 -- | Removes a 'JSVal' and returns nothing.
 --
--- Don't forget to call it on unused 'JSVal's when using a long-lived 'Language.JavaScript.Inline.Core.JSSession'.
+-- Don't forget to call it on unused 'JSVal's when using a long-lived
+-- 'Language.JavaScript.Inline.Core.JSSession'.
 --
 -- Throws on a non-existent 'JSVal'.
 freeJSVal :: JSVal -> JSCode

--- a/inline-js-core/src/Language/JavaScript/Inline/Core/Message/Class.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Core/Message/Class.hs
@@ -1,11 +1,12 @@
 {-# LANGUAGE TypeFamilies #-}
 
 module Language.JavaScript.Inline.Core.Message.Class
-  ( Request(..)
-  , Response(..)
-  , encodeRequest
-  , decodeResponse
-  ) where
+  ( Request (..),
+    Response (..),
+    encodeRequest,
+    decodeResponse,
+  )
+where
 
 import Data.Binary.Get
 import Data.Binary.Put
@@ -13,24 +14,23 @@ import qualified Data.ByteString.Lazy as LBS
 import Language.JavaScript.Inline.Core.MessageCounter
 
 class Request r where
+
   type ResponseOf r
+
   putRequest :: r -> Put
 
 class Response r where
   getResponse :: Get r
 
 encodeRequest :: Request r => MsgId -> r -> LBS.ByteString
-encodeRequest msg_id req =
-  runPut $ do
-    putWord32host $ fromIntegral msg_id
-    putRequest req
+encodeRequest msg_id req = runPut $ do
+  putWord32host $ fromIntegral msg_id
+  putRequest req
 
 decodeResponse :: Response r => LBS.ByteString -> IO r
-decodeResponse buf =
-  case runGetOrFail getResponse buf of
-    Right (rest, _, resp)
-      | LBS.null rest -> pure resp
-    _ ->
-      fail $
-      "Language.JavaScript.Inline.Core.Message.Class.decodeResponse: failed to decode message from " <>
-      show buf
+decodeResponse buf = case runGetOrFail getResponse buf of
+  Right (rest, _, resp) | LBS.null rest -> pure resp
+  _ ->
+    fail $
+      "Language.JavaScript.Inline.Core.Message.Class.decodeResponse: failed to decode message from "
+        <> show buf

--- a/inline-js-core/src/Language/JavaScript/Inline/Core/Message/HSCode.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Core/Message/HSCode.hs
@@ -3,8 +3,9 @@
 {-# LANGUAGE TypeFamilies #-}
 
 module Language.JavaScript.Inline.Core.Message.HSCode
-  ( ExportHSFuncRequest(..)
-  ) where
+  ( ExportHSFuncRequest (..),
+  )
+where
 
 import Data.Binary.Put
 import Language.JavaScript.Inline.Core.HSCode
@@ -12,16 +13,16 @@ import Language.JavaScript.Inline.Core.JSCode
 import Language.JavaScript.Inline.Core.Message.Class
 import Language.JavaScript.Inline.Core.Message.Eval
 
-data ExportHSFuncRequest = ExportHSFuncRequest
-  { sync :: Bool
-  , exportHSFuncRef :: HSFuncRef
-  }
+data ExportHSFuncRequest
+  = ExportHSFuncRequest
+      { sync :: Bool,
+        exportHSFuncRef :: HSFuncRef
+      }
 
 instance Request ExportHSFuncRequest where
+
   type ResponseOf ExportHSFuncRequest = EvalResponse JSVal
+
   putRequest ExportHSFuncRequest {exportHSFuncRef = HSFuncRef r, ..} = do
-    putWord32host $
-      if sync
-        then 5
-        else 3
+    putWord32host $ if sync then 5 else 3
     putWord32host $ fromIntegral r

--- a/inline-js-core/src/Language/JavaScript/Inline/Core/MessageCounter.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Core/MessageCounter.hs
@@ -3,36 +3,32 @@
 {-# LANGUAGE UnboxedTuples #-}
 
 module Language.JavaScript.Inline.Core.MessageCounter
-  ( MsgId(..)
-  , MsgCounter
-  , newMsgCounter
-  , newMsgId
-  ) where
+  ( MsgId (..),
+    MsgCounter,
+    newMsgCounter,
+    newMsgId,
+  )
+where
 
 import Foreign
 import GHC.Exts
 import GHC.Types
 
-newtype MsgId =
-  MsgId Int
+newtype MsgId
+  = MsgId Int
   deriving (Enum, Eq, Integral, Num, Ord, Real, Show)
 
-data MsgCounter =
-  MsgCounter (MutableByteArray# RealWorld)
+data MsgCounter
+  = MsgCounter (MutableByteArray# RealWorld)
 
 unI# :: Int -> Int#
 unI# (I# x) = x
 
 newMsgCounter :: IO MsgCounter
-newMsgCounter =
-  IO $ \s0 ->
-    case newByteArray# (unI# (sizeOf (0 :: Int))) s0 of
-      (# s1, mba #) ->
-        case writeIntArray# mba 0# 1# s1 of
-          s2 -> (# s2, MsgCounter mba #)
+newMsgCounter = IO $ \s0 -> case newByteArray# (unI# (sizeOf (0 :: Int))) s0 of
+  (# s1, mba #) -> case writeIntArray# mba 0# 1# s1 of
+    s2 -> (# s2, MsgCounter mba #)
 
 newMsgId :: MsgCounter -> IO MsgId
-newMsgId (MsgCounter mba) =
-  IO $ \s0 ->
-    case fetchAddIntArray# mba 0# 2# s0 of
-      (# s1, x #) -> (# s1, MsgId (I# x) #)
+newMsgId (MsgCounter mba) = IO $ \s0 -> case fetchAddIntArray# mba 0# 2# s0 of
+  (# s1, x #) -> (# s1, MsgId (I# x) #)

--- a/inline-js-core/src/Language/JavaScript/Inline/Core/NodeVersion.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Core/NodeVersion.hs
@@ -1,33 +1,31 @@
 {-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
 
 module Language.JavaScript.Inline.Core.NodeVersion
-  ( checkNodeVersion
-  ) where
+  ( checkNodeVersion,
+  )
+where
 
 import Control.Monad
 import Data.Version
 import System.Process
 
 split :: (a -> Bool) -> [a] -> [[a]]
-split f l =
-  case foldr w [] l of
-    []:r -> r
-    r -> r
+split f l = case foldr w [] l of
+  [] : r -> r
+  r -> r
   where
     w x acc
-      | f x =
-        case acc of
-          (_:_):_ -> [] : acc
-          _ -> acc
-      | otherwise =
-        case acc of
-          [] -> [[x]]
-          xs:acc' -> (x : xs) : acc'
+      | f x = case acc of
+        (_ : _) : _ -> [] : acc
+        _ -> acc
+      | otherwise = case acc of
+        [] -> [[x]]
+        xs : acc' -> (x : xs) : acc'
 
 nodeVersion :: FilePath -> IO Version
 nodeVersion p = do
-  ('v':s) <- readProcess p ["--version"] ""
-  let vs:tags = split (== '-') s
+  ('v' : s) <- readProcess p ["--version"] ""
+  let vs : tags = split (== '-') s
       v = map read $ split (== '.') vs
   pure $ Version v tags
 
@@ -37,5 +35,5 @@ checkNodeVersion p = do
   unless (v >= Version [12, 2] [])
     $ fail
     $ "Detected node version "
-    <> show v
-    <> ", requires at least node 12.2"
+      <> show v
+      <> ", requires at least node 12.2"

--- a/inline-js-core/src/Language/JavaScript/Inline/Core/Session.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Core/Session.hs
@@ -5,18 +5,19 @@
 {-# LANGUAGE StrictData #-}
 
 module Language.JavaScript.Inline.Core.Session
-  ( JSSessionOpts(..)
-  , defJSSessionOpts
-  , JSSession
-  , newJSSession
-  , closeJSSession
-  , withJSSession
-  , sendMsg
-  , newHSFunc
-  , nodeStdIn
-  , nodeStdOut
-  , nodeStdErr
-  ) where
+  ( JSSessionOpts (..),
+    defJSSessionOpts,
+    JSSession,
+    newJSSession,
+    closeJSSession,
+    withJSSession,
+    sendMsg,
+    newHSFunc,
+    nodeStdIn,
+    nodeStdOut,
+    nodeStdErr,
+  )
+where
 
 import Control.Concurrent
 import Control.Concurrent.STM
@@ -47,61 +48,72 @@ import System.IO.Unsafe
 import System.Process
 
 -- | Options to initialize a 'JSSession'.
-data JSSessionOpts = JSSessionOpts
-  { nodePath :: FilePath -- ^ Path to the @node@ executable.
-  , nodeExtraArgs :: [String] -- ^ Extra arguments passed to @node@. Can't be accessed via @process.argv@.
-  , nodeWorkDir :: Maybe FilePath -- ^ Working directory of @node@. To @import()@ npm installed modules, set to the directory containing @node_modules@.
-  , nodeExtraEnv :: [(String, String)] -- ^ Extra environment variables to be passed to @node@.
-  , nodeStdInInherit, nodeStdOutInherit, nodeStdErrInherit :: Bool -- ^ Inherit stdio handles of @node@ from the host process.
-  , nodeSharedMemSize :: Int -- ^ Shared memory size of @node@ in megabytes.
-  }
+data JSSessionOpts
+  = JSSessionOpts
+      { -- | Path to the @node@ executable.
+        nodePath :: FilePath,
+        -- | Extra arguments passed to @node@. Can't be accessed via
+        -- @process.argv@.
+        nodeExtraArgs :: [String],
+        -- | Working directory of @node@. To @import()@ npm installed modules,
+        -- set to the directory containing @node_modules@.
+        nodeWorkDir :: Maybe FilePath,
+        -- | Extra environment variables to be passed to @node@.
+        nodeExtraEnv :: [(String, String)],
+        -- | Inherit stdio handles of @node@ from the host process.
+        nodeStdInInherit, nodeStdOutInherit, nodeStdErrInherit :: Bool,
+        -- | Shared memory size of @node@ in megabytes.
+        nodeSharedMemSize :: Int
+      }
 
 -- | A sensible default 'JSSessionOpts'.
 --
--- Uses @node@ from @PATH@ and sets the inherit flags to 'False'.
--- Shared memory size defaults to 1MB.
+-- Uses @node@ from @PATH@ and sets the inherit flags to 'False'. Shared memory
+-- size defaults to 1MB.
 --
--- See doc of 'Language.JavaScript.Inline.Core.exportSyncHSFunc'
--- for what the "shared memory" is about.
+-- See doc of 'Language.JavaScript.Inline.Core.exportSyncHSFunc' for what the
+-- "shared memory" is about.
 {-# NOINLINE defJSSessionOpts #-}
 defJSSessionOpts :: JSSessionOpts
-defJSSessionOpts =
-  unsafePerformIO $ do
-    _datadir <- Paths_inline_js_core.getDataDir
-    pure
-      JSSessionOpts
-        { nodePath = "node"
-        , nodeExtraArgs = []
-        , nodeWorkDir = Nothing
-        , nodeExtraEnv = []
-        , nodeStdInInherit = False
-        , nodeStdOutInherit = False
-        , nodeStdErrInherit = False
-        , nodeSharedMemSize = 1
-        }
+defJSSessionOpts = unsafePerformIO $ do
+  _datadir <- Paths_inline_js_core.getDataDir
+  pure JSSessionOpts
+    { nodePath = "node",
+      nodeExtraArgs = [],
+      nodeWorkDir = Nothing,
+      nodeExtraEnv = [],
+      nodeStdInInherit = False,
+      nodeStdOutInherit = False,
+      nodeStdErrInherit = False,
+      nodeSharedMemSize = 1
+    }
 
 -- | Represents an active @node@ process and related IPC states.
-data JSSession = JSSession
-  { closeJSSession :: IO () -- ^ Shuts down a 'JSSession'. Safe to call more than once.
-  , sendData :: LBS.ByteString -> IO ()
-  , recvData :: MsgId -> IO LBS.ByteString
-  , nodeStdIn, nodeStdOut, nodeStdErr :: Maybe Handle -- ^ Available when the corresponding inherit flag in 'JSSessionOpts' is 'False'.
-  , msgCounter :: MsgCounter
-  , hsFuncs :: IORef (IntMap HSFunc, Int)
-  }
+data JSSession
+  = JSSession
+      { -- | Shuts down a 'JSSession'. Safe to call more than once.
+        closeJSSession :: IO (),
+        sendData :: LBS.ByteString -> IO (),
+        recvData :: MsgId -> IO LBS.ByteString,
+        -- | Available when the corresponding inherit flag in 'JSSessionOpts' is
+        -- 'False'.
+        nodeStdIn, nodeStdOut, nodeStdErr :: Maybe Handle,
+        msgCounter :: MsgCounter,
+        hsFuncs :: IORef (IntMap HSFunc, Int)
+      }
 
 -- | Initializes a new 'JSSession'.
 newJSSession :: JSSessionOpts -> IO JSSession
 newJSSession JSSessionOpts {..} = do
   checkNodeVersion nodePath
-  (mjss_dir, mjss) <-
-    do mjss_dir <- (</> "jsbits") <$> Paths_inline_js_core.getDataDir
-       case nodeWorkDir of
-         Just p -> do
-           mjss <- listDirectory mjss_dir
-           for_ mjss $ \mjs -> copyFile (mjss_dir </> mjs) (p </> mjs)
-           pure (p, mjss)
-         _ -> pure (mjss_dir, [])
+  (mjss_dir, mjss) <- do
+    mjss_dir <- (</> "jsbits") <$> Paths_inline_js_core.getDataDir
+    case nodeWorkDir of
+      Just p -> do
+        mjss <- listDirectory mjss_dir
+        for_ mjss $ \mjs -> copyFile (mjss_dir </> mjs) (p </> mjs)
+        pure (p, mjss)
+      _ -> pure (mjss_dir, [])
   parent_env <- getEnvironment
   (rh0, wh0) <- createPipe
   (rh1, wh1) <- createPipe
@@ -112,122 +124,106 @@ newJSSession JSSessionOpts {..} = do
   rfd1 <- handleToFd rh1
   (_m_stdin, _m_stdout, _m_stderr, _ph) <-
     createProcess
-      (proc nodePath $
-       nodeExtraArgs <>
-       [ "--experimental-modules"
-       , mjss_dir </> "eval.mjs"
-       , show nodeSharedMemSize
-       , show wfd0
-       , show rfd1
-       ])
-        { cwd = nodeWorkDir
-        , env = Just $ nodeExtraEnv <> parent_env
-        , std_in =
-            if nodeStdInInherit
-              then Inherit
-              else CreatePipe
-        , std_out =
-            if nodeStdOutInherit
-              then Inherit
-              else CreatePipe
-        , std_err =
-            if nodeStdErrInherit
-              then Inherit
-              else CreatePipe
+      ( proc nodePath $
+          nodeExtraArgs
+            <> [ "--experimental-modules",
+                 mjss_dir </> "eval.mjs",
+                 show nodeSharedMemSize,
+                 show wfd0,
+                 show rfd1
+               ]
+      )
+        { cwd = nodeWorkDir,
+          env = Just $ nodeExtraEnv <> parent_env,
+          std_in = if nodeStdInInherit then Inherit else CreatePipe,
+          std_out = if nodeStdOutInherit then Inherit else CreatePipe,
+          std_err = if nodeStdErrInherit then Inherit else CreatePipe
         }
   send_queue <- newTQueueIO
   send_tid <-
     forkIO $
-    let w = do
-          buf <- atomically $ readTQueue send_queue
-          hPutBuilder wh1 $
-            word32LE (fromIntegral $ LBS.length buf) <> lazyByteString buf
-          w
-     in w
+      let w = do
+            buf <- atomically $ readTQueue send_queue
+            hPutBuilder wh1 $
+              word32LE (fromIntegral $ LBS.length buf)
+                <> lazyByteString buf
+            w
+       in w
   _hs_funcs <- newIORef (IntMap.empty, 1)
   recv_map <- newTVarIO IntMap.empty
   recv_tid <-
     forkIO $
-    let w = do
-          (len :: Word32) <- peekHandle rh0
-          (msg_id :: Word32) <- peekHandle rh0
-          if odd msg_id
-            then do
-              let len' = fromIntegral len - 4
-                  msg_id' = fromIntegral msg_id
-              buf <- hGetLBS rh0 len'
-              atomically $ modifyTVar' recv_map $ IntMap.insert msg_id' buf
-            else do
-              (_ :: Word32) <- peekHandle rh0
-              (hs_func_ref :: Word32) <- peekHandle rh0
-              (args_len :: Word32) <- peekHandle rh0
-              args <-
-                replicateM (fromIntegral args_len) $ do
+      let w = do
+            (len :: Word32) <- peekHandle rh0
+            (msg_id :: Word32) <- peekHandle rh0
+            if odd msg_id
+              then do
+                let len' = fromIntegral len - 4
+                    msg_id' = fromIntegral msg_id
+                buf <- hGetLBS rh0 len'
+                atomically $ modifyTVar' recv_map $ IntMap.insert msg_id' buf
+              else do
+                (_ :: Word32) <- peekHandle rh0
+                (hs_func_ref :: Word32) <- peekHandle rh0
+                (args_len :: Word32) <- peekHandle rh0
+                args <- replicateM (fromIntegral args_len) $ do
                   (arg_len :: Word32) <- peekHandle rh0
                   hGetLBS rh0 (fromIntegral arg_len)
-              void $
-                forkIO $ do
-                  r <-
-                    tryAny $ do
-                      let ref = fromIntegral hs_func_ref
-                      hs_func <- (IntMap.! ref) . fst <$> readIORef _hs_funcs
-                      runHSFunc hs_func args
-                  atomically $
-                    writeTQueue send_queue $
-                    runPut $ do
-                      putWord32host msg_id
-                      putWord32host 4
-                      case r of
-                        Left err -> do
-                          putWord32host 1
-                          putBuilder $ stringUtf8 $ show err
-                        Right buf -> do
-                          putWord32host 0
-                          putLazyByteString buf
-          w
-     in w
+                void $ forkIO $ do
+                  r <- tryAny $ do
+                    let ref = fromIntegral hs_func_ref
+                    hs_func <- (IntMap.! ref) . fst <$> readIORef _hs_funcs
+                    runHSFunc hs_func args
+                  atomically $ writeTQueue send_queue $ runPut $ do
+                    putWord32host msg_id
+                    putWord32host 4
+                    case r of
+                      Left err -> do
+                        putWord32host 1
+                        putBuilder $ stringUtf8 $ show err
+                      Right buf -> do
+                        putWord32host 0
+                        putLazyByteString buf
+            w
+       in w
   _msg_counter <- newMsgCounter
-  _close <-
-    once $ do
-      killThread send_tid
-      killThread recv_tid
-      terminateProcess _ph
-      atomicWriteIORef _hs_funcs (IntMap.empty, 1)
-      case nodeWorkDir of
-        Just p -> for_ mjss $ \mjs -> removeFile $ p </> mjs
-        _ -> pure ()
-  pure
-    JSSession
-      { closeJSSession = _close
-      , sendData = atomically . writeTQueue send_queue
-      , recvData =
-          \msg_id ->
-            atomically $ do
-              m <- readTVar recv_map
-              case IntMap.updateLookupWithKey
-                     (\_ _ -> Nothing)
-                     (coerce msg_id)
-                     m of
-                (Just buf, m') -> do
-                  writeTVar recv_map m'
-                  pure buf
-                _ -> retry
-      , nodeStdIn = _m_stdin
-      , nodeStdOut = _m_stdout
-      , nodeStdErr = _m_stderr
-      , msgCounter = _msg_counter
-      , hsFuncs = _hs_funcs
-      }
+  _close <- once $ do
+    killThread send_tid
+    killThread recv_tid
+    terminateProcess _ph
+    atomicWriteIORef _hs_funcs (IntMap.empty, 1)
+    case nodeWorkDir of
+      Just p -> for_ mjss $ \mjs -> removeFile $ p </> mjs
+      _ -> pure ()
+  pure JSSession
+    { closeJSSession = _close,
+      sendData = atomically . writeTQueue send_queue,
+      recvData = \msg_id -> atomically $ do
+        m <- readTVar recv_map
+        case IntMap.updateLookupWithKey
+          (\_ _ -> Nothing)
+          (coerce msg_id)
+          m of
+          (Just buf, m') -> do
+            writeTVar recv_map m'
+            pure buf
+          _ -> retry,
+      nodeStdIn = _m_stdin,
+      nodeStdOut = _m_stdout,
+      nodeStdErr = _m_stderr,
+      msgCounter = _msg_counter,
+      hsFuncs = _hs_funcs
+    }
 
 -- | Use 'bracket' to ensure 'closeJSSession' is called.
 withJSSession :: JSSessionOpts -> (JSSession -> IO r) -> IO r
 withJSSession opts = bracket (newJSSession opts) closeJSSession
 
 sendMsg ::
-     (Request r, Response (ResponseOf r))
-  => JSSession
-  -> r
-  -> IO (IO (ResponseOf r))
+  (Request r, Response (ResponseOf r)) =>
+  JSSession ->
+  r ->
+  IO (IO (ResponseOf r))
 sendMsg JSSession {..} msg = do
   msg_id <- newMsgId msgCounter
   sendData $ encodeRequest msg_id msg
@@ -236,8 +232,9 @@ sendMsg JSSession {..} msg = do
     decodeResponse buf
 
 newHSFunc :: JSSession -> Bool -> HSFunc -> IO (ExportHSFuncRequest, IO ())
-newHSFunc JSSession {..} s f =
-  atomicModifyIORef' hsFuncs $ \(m, l) ->
-    ( (IntMap.insert l f m, succ l)
-    , ( ExportHSFuncRequest {sync = s, exportHSFuncRef = coerce l}
-      , atomicModifyIORef' hsFuncs $ \(m', l') -> ((IntMap.delete l m', l'), ())))
+newHSFunc JSSession {..} s f = atomicModifyIORef' hsFuncs $ \(m, l) ->
+  ( (IntMap.insert l f m, succ l),
+    ( ExportHSFuncRequest {sync = s, exportHSFuncRef = coerce l},
+      atomicModifyIORef' hsFuncs $ \(m', l') -> ((IntMap.delete l m', l'), ())
+    )
+  )

--- a/inline-js/src/Language/JavaScript/Inline.hs
+++ b/inline-js/src/Language/JavaScript/Inline.hs
@@ -2,56 +2,58 @@
 {-# LANGUAGE ViewPatterns #-}
 
 module Language.JavaScript.Inline
-  ( expr
-  , block
-  , module Language.JavaScript.Inline.Core
-  ) where
+  ( expr,
+    block,
+    module Language.JavaScript.Inline.Core,
+  )
+where
 
 import Data.ByteString.Builder
 import Data.Coerce
 import Data.List (nub)
 import qualified Language.Haskell.TH as TH
 import Language.Haskell.TH (Q)
-import Language.Haskell.TH.Quote (QuasiQuoter(..))
+import Language.Haskell.TH.Quote (QuasiQuoter (..))
 import Language.JavaScript.Inline.Class
 import Language.JavaScript.Inline.Core
-import Language.JavaScript.Parser.Lexer (Token(..), alexTestTokeniser)
+import Language.JavaScript.Parser.Lexer (Token (..), alexTestTokeniser)
 
 qq :: (String -> Q TH.Exp) -> QuasiQuoter
 qq myQQ =
   QuasiQuoter
-    { quoteExp = myQQ
-    , quotePat = error "Language.JavaScript.Inline: quotePat"
-    , quoteType = error "Language.JavaScript.Inline: quoteType"
-    , quoteDec = error "Language.JavaScript.Inline: quoteDec"
+    { quoteExp = myQQ,
+      quotePat = error "Language.JavaScript.Inline: quotePat",
+      quoteType = error "Language.JavaScript.Inline: quoteType",
+      quoteDec = error "Language.JavaScript.Inline: quoteDec"
     }
 
--- | Produces expression splices with type @'FromEvalResult' a => 'JSSession' -> 'IO' a@.
--- Some things to keep in mind here:
+-- | Produces expression splices with type @'FromEvalResult' a => 'JSSession' ->
+-- 'IO' a@. Some things to keep in mind here:
 --
--- 1. The spliced string should be a valid JavaScript expression.
--- To write control-flow statements, it's better to use 'block' instead.
+-- 1. The spliced string should be a valid JavaScript expression. To write
+--    control-flow statements, it's better to use 'block' instead.
 --
 -- 2. The spliced JavaScript expression is wrapped in an async arrow function,
--- and the returned @Promise@ is resolved to get the result to the Haskell side.
--- This means it's possible to use @await@ here. This applies to both 'expr' and 'block'.
+--    and the returned @Promise@ is resolved to get the result to the Haskell
+--    side. This means it's possible to use @await@ here. This applies to both
+--    'expr' and 'block'.
 --
--- 3. Use @$some_hs_var@ to refer to an in-scope Haskell variable.
--- The variable's type should be an 'ToJSCode' instance.
--- 'ToJSCode' class is not exposed, but it works for any 'Data.Aeson.ToJSON' instance,
--- plus 'JSVal' and several @bytestring@ types.
+-- 3. Use @$some_hs_var@ to refer to an in-scope Haskell variable. The
+--    variable's type should be an 'ToJSCode' instance. 'ToJSCode' class is not
+--    exposed, but it works for any 'Data.Aeson.ToJSON' instance, plus 'JSVal'
+--    and several @bytestring@ types.
 --
--- 4. Likewise, 'FromEvalResult' isn't exposed either, but it works for 'Data.Aeson.FromJSON'
--- instances, 'JSVal's and @bytestring@ types. Explicit type annotation of the returned value
--- is often needed.
+-- 4. Likewise, 'FromEvalResult' isn't exposed either, but it works for
+--    'Data.Aeson.FromJSON' instances, 'JSVal's and @bytestring@ types. Explicit
+--    type annotation of the returned value is often needed.
 expr :: QuasiQuoter
 expr = qq expressionQuasiQuoter
 
 -- | Produces expression splices with the same type of 'expr'.
 --
 -- The spliced string should be a series of valid JavaScript statements.
--- JavaScript control-flow features (e.g. loops, try/catch) are supported.
--- Use @return@ to return the result.
+-- JavaScript control-flow features (e.g. loops, try/catch) are supported. Use
+-- @return@ to return the result.
 --
 -- The other rules of 'expr' also apply to 'block'.
 block :: QuasiQuoter
@@ -64,44 +66,44 @@ blockQuasiQuoter :: String -> Q TH.Exp
 blockQuasiQuoter input =
   let tokens = either error id $ alexTestTokeniser input
       antiquotedParameterNames =
-        nub [name | IdentifierToken {tokenLiteral = ('$':name)} <- tokens]
+        nub [name | IdentifierToken {tokenLiteral = ('$' : name)} <- tokens]
       wrappedCode = wrapCode input antiquotedParameterNames
-   in [|\session ->
+   in [|
+        \session ->
           withFromEvalResult $ \p f -> do
             result <- eval session $ JSCode ($(wrappedCode) p)
-            either fail pure (f result)|]
+            either fail pure (f result)
+        |]
 
 -- |
 -- This fits the quasiquoted content into following format:
 --
--- (async (a, b, c) => {
---   return a + b + c;
--- })(1, 2, 3)
+-- (async (a, b, c) => {return a + b + c;})(1, 2, 3)
 --
--- where the argumentList is "a, b, c",
--- the argumentValues are "1, 2, 3"
--- and the code is "a + b + c"
---
+-- where the argumentList is "a, b, c", the argumentValues are "1, 2, 3" and the
+-- code is "a + b + c"
 wrapCode :: String -> [String] -> Q TH.Exp
 wrapCode code antiquotedNames =
-  [|\p ->
+  [|
+    \p ->
       mconcat
-        [ string7 "(async ( "
-        , $(argumentList antiquotedNames)
-        , string7 " ) => { "
-        , stringUtf8 code
-        , string7 " })( "
-        , $(argumentValues antiquotedNames)
-        , string7 " ).then("
-        , coerce p
-        , string7 ")"
-        ]|]
+        [ string7 "(async ( ",
+          $(argumentList antiquotedNames),
+          string7 " ) => { ",
+          stringUtf8 code,
+          string7 " })( ",
+          $(argumentValues antiquotedNames),
+          string7 " ).then(",
+          coerce p,
+          string7 ")"
+        ]
+    |]
 
 argumentList :: [String] -> Q TH.Exp
 argumentList rawNames =
   case rawNames of
     [] -> [|string7 ""|]
-    (firstName:names) ->
+    (firstName : names) ->
       foldr
         (\name acc -> [|$(acc) <> string7 ", $" <> string7 name|])
         [|string7 ('$' : firstName)|]
@@ -111,10 +113,14 @@ argumentValues :: [String] -> Q TH.Exp
 argumentValues rawNames =
   case rawNames of
     [] -> [|string7 ""|]
-    (firstName:names) ->
+    (firstName : names) ->
       foldr
-        (\name acc ->
-           [|$(acc) <> string7 ", " <>
-             coerce (toJSCode $(TH.varE $ TH.mkName name))|])
+        ( \name acc ->
+            [|
+              $(acc)
+                <> string7 ", "
+                <> coerce (toJSCode $(TH.varE $ TH.mkName name))
+              |]
+        )
         [|coerce (toJSCode $(TH.varE $ TH.mkName firstName))|]
         names

--- a/inline-js/tests/Main.hs
+++ b/inline-js/tests/Main.hs
@@ -1,4 +1,7 @@
-import Test.Tasty (defaultMain, testGroup)
+import Test.Tasty
+  ( defaultMain,
+    testGroup,
+  )
 import qualified Tests.Echo as Echo
 import qualified Tests.Evaluation as Evaluation
 import qualified Tests.LeftPad as LeftPad
@@ -10,11 +13,11 @@ main :: IO ()
 main = do
   tests <-
     sequence
-      [ Echo.tests
-      , Evaluation.tests
-      , LeftPad.tests
-      , PingPong.tests
-      , Quotation.tests
-      , Wasm.tests
+      [ Echo.tests,
+        Evaluation.tests,
+        LeftPad.tests,
+        PingPong.tests,
+        Quotation.tests,
+        Wasm.tests
       ]
   defaultMain $ testGroup "inline-js Test Suite" tests

--- a/inline-js/tests/Tests/Echo.hs
+++ b/inline-js/tests/Tests/Echo.hs
@@ -1,8 +1,9 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 module Tests.Echo
-  ( tests
-  ) where
+  ( tests,
+  )
+where
 
 import Control.Monad
 import qualified Data.ByteString.Lazy as LBS
@@ -19,16 +20,18 @@ genLBS = LBS.pack <$> vectorOf 1024 arbitrary
 tests :: IO TestTree
 tests = do
   datadir <- Paths_inline_js.getDataDir
-  pure $
-    testProperty "Echo" $
-    withMaxSuccess 8 $
-    monadicIO $
-    forAllM genLBS $ \buf ->
-      run $
-      withJSSession defJSSessionOpts $ \s -> do
-        mod_ref <- importMJS s $ datadir </> "testdata" </> "echo.mjs"
-        buf_ref <- alloc s buf
-        buf' <-
-          eval s $
-          deRefJSVal mod_ref <> ".identity(" <> deRefJSVal buf_ref <> ")"
-        unless (buf' == buf) $ fail "Echo mismatch"
+  pure
+    $ testProperty "Echo"
+    $ withMaxSuccess 8
+    $ monadicIO
+    $ forAllM genLBS
+    $ \buf -> run $ withJSSession defJSSessionOpts $ \s -> do
+      mod_ref <- importMJS s $ datadir </> "testdata" </> "echo.mjs"
+      buf_ref <- alloc s buf
+      buf' <-
+        eval s $
+          deRefJSVal mod_ref
+            <> ".identity("
+            <> deRefJSVal buf_ref
+            <> ")"
+      unless (buf' == buf) $ fail "Echo mismatch"

--- a/inline-js/tests/Tests/LeftPad.hs
+++ b/inline-js/tests/Tests/LeftPad.hs
@@ -1,8 +1,9 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 module Tests.LeftPad
-  ( tests
-  ) where
+  ( tests,
+  )
+where
 
 import qualified Data.ByteString.Lazy as LBS
 import Distribution.Simple.Utils
@@ -15,24 +16,24 @@ import Test.Tasty.HUnit
 
 tests :: IO TestTree
 tests =
-  pure
-    $ testGroup
-        "left-pad"
-        [ testCase "should install left-pad from npm and run it" $ do
-            tmpdir <- getTemporaryDirectory
-            x <-
-              withTempDirectory silent tmpdir "inline-js-test-suite-left-pad" $ \p ->
-                do
-                  _ <-
-                    readCreateProcess
-                      ( (shell "npm install left-pad")
-                          { cwd = Just p,
-                            std_err = CreatePipe
-                            }
-                        )
-                      ""
-                  withJSSession defJSSessionOpts {nodeWorkDir = Just p} $ \s -> do
-                    mref <- eval s "import('left-pad').then(m => m.default)"
-                    eval s $ deRefJSVal mref <> "('foo', 5)"
-            x @?= ("  foo" :: LBS.ByteString)
-          ]
+  pure $
+    testGroup
+      "left-pad"
+      [ testCase "should install left-pad from npm and run it" $ do
+          tmpdir <- getTemporaryDirectory
+          x <-
+            withTempDirectory silent tmpdir "inline-js-test-suite-left-pad" $ \p ->
+              do
+                _ <-
+                  readCreateProcess
+                    ( (shell "npm install left-pad")
+                        { cwd = Just p,
+                          std_err = CreatePipe
+                        }
+                    )
+                    ""
+                withJSSession defJSSessionOpts {nodeWorkDir = Just p} $ \s -> do
+                  mref <- eval s "import('left-pad').then(m => m.default)"
+                  eval s $ deRefJSVal mref <> "('foo', 5)"
+          x @?= ("  foo" :: LBS.ByteString)
+      ]

--- a/inline-js/tests/Tests/PingPong.hs
+++ b/inline-js/tests/Tests/PingPong.hs
@@ -3,8 +3,9 @@
 {-# LANGUAGE TypeApplications #-}
 
 module Tests.PingPong
-  ( tests
-  ) where
+  ( tests,
+  )
+where
 
 import Control.Monad hiding (fail)
 import Control.Monad.Fail
@@ -16,11 +17,17 @@ import Data.Maybe
 import qualified Data.Text as Text
 import GHC.Exts
 import Language.JavaScript.Inline.Core
-import Prelude hiding (fail)
 import Test.QuickCheck.Gen
 import Test.QuickCheck.Monadic
-import Test.Tasty (TestTree, withResource)
-import Test.Tasty.QuickCheck (testProperty, withMaxSuccess)
+import Test.Tasty
+  ( TestTree,
+    withResource,
+  )
+import Test.Tasty.QuickCheck
+  ( testProperty,
+    withMaxSuccess,
+  )
+import Prelude hiding (fail)
 
 genString :: Gen Text.Text
 genString = Text.pack <$> listOf (choose ('\x00', '\xFF'))
@@ -28,49 +35,48 @@ genString = Text.pack <$> listOf (choose ('\x00', '\xFF'))
 genValue :: Gen Value
 genValue =
   frequency
-    [ ( 1
-      , oneof
-          [ Object . fromList <$> listOf ((,) <$> genString <*> genValue)
-          , Array . fromList <$> listOf genValue
-          ])
-    , ( 64
-      , oneof
-          [ String <$> genString
-          , Number . fromIntegral <$> chooseAny @Int32
-          , Bool <$> chooseAny
-          , pure Null
-          ])
+    [ ( 1,
+        oneof
+          [ Object . fromList <$> listOf ((,) <$> genString <*> genValue),
+            Array . fromList <$> listOf genValue
+          ]
+      ),
+      ( 64,
+        oneof
+          [ String <$> genString,
+            Number . fromIntegral <$> chooseAny @Int32,
+            Bool <$> chooseAny,
+            pure Null
+          ]
+      )
     ]
 
 tests :: IO TestTree
-tests =
-  pure $
-  withResource setup teardown $ \getSetup ->
-    testProperty "Ping-Pong Matching" $
-    withMaxSuccess 1024 $
-    monadicIO $ do
-      s <- liftIO getSetup
-      (f, _) <-
-        liftIO $
-        exportHSFunc s $
-        HSFunc $ \bufs -> pure $ "[" <> mconcat (intersperse "," bufs) <> "]"
-      (f', _) <- liftIO $ exportSyncHSFunc s $ HSFunc $ pure . mconcat
-      forAllM genValue $ \v ->
-        run $ do
-          v_buf_ref <- alloc s $ encode v
-          v_buf_ref' <-
-            eval s $ deRefJSVal f <> "(" <> takeJSVal v_buf_ref <> ")"
-          _recv_v <-
-            fmap (fromJust . decode') $
-            eval s $
-            jsonStringify
-              (jsonParse $
-               bufferToString $
-               deRefJSVal f' <> "(" <> deRefJSVal v_buf_ref' <> ")")
-          unless (Array [v] == _recv_v) $
-            fail $ "pingpong: pong mismatch: " <> show (v, _recv_v)
-          () <- eval s $ freeJSVal v_buf_ref'
-          pure ()
+tests = pure $ withResource setup teardown $ \getSetup ->
+  testProperty "Ping-Pong Matching" $ withMaxSuccess 1024 $ monadicIO $ do
+    s <- liftIO getSetup
+    (f, _) <- liftIO $ exportHSFunc s $ HSFunc $ \bufs ->
+      pure $ "[" <> mconcat (intersperse "," bufs) <> "]"
+    (f', _) <- liftIO $ exportSyncHSFunc s $ HSFunc $ pure . mconcat
+    forAllM genValue $ \v -> run $ do
+      v_buf_ref <- alloc s $ encode v
+      v_buf_ref' <- eval s $ deRefJSVal f <> "(" <> takeJSVal v_buf_ref <> ")"
+      _recv_v <-
+        fmap (fromJust . decode') $ eval s $
+          jsonStringify
+            ( jsonParse
+                $ bufferToString
+                $ deRefJSVal f'
+                  <> "("
+                  <> deRefJSVal v_buf_ref'
+                  <> ")"
+            )
+      unless (Array [v] == _recv_v) $ fail $
+        "pingpong: pong mismatch: "
+          <> show
+            (v, _recv_v)
+      () <- eval s $ freeJSVal v_buf_ref'
+      pure ()
 
 setup :: IO JSSession
 setup = newJSSession defJSSessionOpts

--- a/inline-js/tests/Tests/Quotation.hs
+++ b/inline-js/tests/Tests/Quotation.hs
@@ -1,15 +1,19 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE QuasiQuotes #-}
-{-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Tests.Quotation
-  ( tests
-  ) where
+  ( tests,
+  )
+where
 
 import Control.Monad (forM_)
-import Data.Aeson (FromJSON(..), ToJSON(..))
+import Data.Aeson
+  ( FromJSON (..),
+    ToJSON (..),
+  )
 import qualified Data.ByteString.Lazy.Char8 as LBS
 import Data.Text (pack)
 import GHC.Generics (Generic)
@@ -18,59 +22,69 @@ import Test.Tasty
 import Test.Tasty.HUnit
 
 -- Datatypes used by tests
-newtype GameWorld = GameWorld
-  { playerCharacter :: PlayerCharacter
-  } deriving (Generic, ToJSON, FromJSON)
+newtype GameWorld
+  = GameWorld
+      { playerCharacter :: PlayerCharacter
+      }
+  deriving (Generic, ToJSON, FromJSON)
 
-data PlayerCharacter = PlayerCharacter
-  { hp :: Integer
-  , maxHp :: Integer
-  , isDead :: Bool
-  } deriving (Generic, ToJSON, FromJSON)
+data PlayerCharacter
+  = PlayerCharacter
+      { hp :: Integer,
+        maxHp :: Integer,
+        isDead :: Bool
+      }
+  deriving (Generic, ToJSON, FromJSON)
 
 -- A test of the initial implementation, with manual Value conversion
 tests :: IO TestTree
 tests =
-  pure
-    $ testGroup
-        "Inline JavaScript QuasiQuoter"
-        [ testCase "should add two numbers and return a Number" $ do
-            result <- withJSSession defJSSessionOpts [expr| 1 + 3 |]
-            result @?= (4 :: Int),
-          testCase "should concatenate two Strings" $ do
-            result <- withJSSession defJSSessionOpts [expr| "hello" + " goodbye" |]
-            result @?= "hello goodbye",
-          testCase "should take in a Haskell String and return it" $ do
-            let sentence = "This is a String"
-            result <- withJSSession defJSSessionOpts [expr| $sentence |]
-            result @?= sentence,
-          testCase "should append a Haskell-inserted String to a JavaScript String" $ do
+  pure $
+    testGroup
+      "Inline JavaScript QuasiQuoter"
+      [ testCase "should add two numbers and return a Number" $ do
+          result <- withJSSession defJSSessionOpts [expr| 1 + 3 |]
+          result @?= (4 :: Int),
+        testCase "should concatenate two Strings" $ do
+          result <- withJSSession defJSSessionOpts [expr| "hello" + " goodbye" |]
+          result @?= "hello goodbye",
+        testCase "should take in a Haskell String and return it" $ do
+          let sentence = "This is a String"
+          result <- withJSSession defJSSessionOpts [expr| $sentence |]
+          result @?= sentence,
+        testCase "should append a Haskell-inserted String to a JavaScript String" $
+          do
             let sentence = "Pineapple"
-            result <-
-              withJSSession defJSSessionOpts [expr| $sentence + " on pizza" |]
-            result @?= "Pineapple on pizza",
-          testCase "should work when reusing the same variable in the same splice" $ do
-            let myNumber = 4 :: Int
-            result <- withJSSession defJSSessionOpts [expr| $myNumber + $myNumber |]
-            result @?= (8 :: Int),
-          testCase "should compute the result of three separate variables" $ do
-            let firstNumber = 1 :: Int
-                secondNumber = 2 :: Int
-                thirdNumber = 9 :: Int
             result <-
               withJSSession
                 defJSSessionOpts
-                [expr| $firstNumber + $secondNumber + $thirdNumber |]
-            result @?= (12 :: Int),
-          testCase
-            "should not share state when reusing the same variable across splices" $ do
+                [expr| $sentence + " on pizza" |]
+            result @?= "Pineapple on pizza",
+        testCase "should work when reusing the same variable in the same splice" $
+          do
+            let myNumber = 4 :: Int
+            result <- withJSSession defJSSessionOpts [expr| $myNumber + $myNumber |]
+            result @?= (8 :: Int),
+        testCase "should compute the result of three separate variables" $ do
+          let firstNumber = 1 :: Int
+              secondNumber = 2 :: Int
+              thirdNumber = 9 :: Int
+          result <-
+            withJSSession
+              defJSSessionOpts
+              [expr| $firstNumber + $secondNumber + $thirdNumber |]
+          result @?= (12 :: Int),
+        testCase
+          "should not share state when reusing the same variable across splices"
+          $ do
             let myNumber = 3 :: Int
             result1 <- withJSSession defJSSessionOpts [expr| $myNumber + 3 |]
             result2 <- withJSSession defJSSessionOpts [expr| $myNumber + 4 |]
             result1 @?= (6 :: Int)
             result2 @?= (7 :: Int),
-          testCase
-            "should not share state when resuing the same variable name across splices" $ do
+        testCase
+          "should not share state when resuing the same variable name across splices"
+          $ do
             let firstOperation =
                   let word = pack "Bananas"
                    in do
@@ -84,34 +98,37 @@ tests =
             firstOperation
             secondOperation
             firstOperation,
-          testCase
-            "should not collide names when reusing the same variable name across splices in the same session" $ do
+        testCase
+          "should not collide names when reusing the same variable name across splices in the same session"
+          $ do
             session <- newJSSession defJSSessionOpts
-            forM_ [1 :: Int .. 10]
-              $ const $ do
+            forM_ [1 :: Int .. 10] $ const $ do
               let word = pack "Bananas"
               result <- [expr| $word |] session
               result @?= word
             closeJSSession session,
-          testCase "should process a simple block expression" $ do
-            let myNumber = 3 :: Int
-            result <-
-              withJSSession
-                defJSSessionOpts
-                [block|
+        testCase "should process a simple block expression" $ do
+          let myNumber = 3 :: Int
+          result <-
+            withJSSession
+              defJSSessionOpts
+              [block|
             const myNumber = $myNumber;
             return "Your number was: " + myNumber;
           |]
-            result @?= pack "Your number was: 3",
-          testCase "should process a complex block expression" $ do
-            let gameWorld =
-                  GameWorld
-                    { playerCharacter = PlayerCharacter {hp = 10, maxHp = 30, isDead = False}
-                      }
-            result <-
-              withJSSession
-                defJSSessionOpts
-                [block|
+          result @?= pack "Your number was: 3",
+        testCase "should process a complex block expression" $ do
+          let gameWorld = GameWorld
+                { playerCharacter = PlayerCharacter
+                    { hp = 10,
+                      maxHp = 30,
+                      isDead = False
+                    }
+                }
+          result <-
+            withJSSession
+              defJSSessionOpts
+              [block|
             const gameWorld = $gameWorld;
             const player = gameWorld.playerCharacter;
             const renderHp = somePlayer => somePlayer.hp + "/" + somePlayer.maxHp;
@@ -121,13 +138,12 @@ tests =
               return "Your HP: " + renderHp(player);
             }
           |]
-            result @?= "Your HP: 10/30",
-          testCase "should pass and return a lazy ByteString" $ do
-            let buf = LBS.pack "SPICE GIRL WANNABEEE"
-            result <-
-              withJSSession defJSSessionOpts $ \s -> do
-                () <- [expr| global.x = $buf |] s
-                (v :: JSVal) <- [expr| global.x |] s
-                [expr| $v |] s
-            result @?= buf
-          ]
+          result @?= "Your HP: 10/30",
+        testCase "should pass and return a lazy ByteString" $ do
+          let buf = LBS.pack "SPICE GIRL WANNABEEE"
+          result <- withJSSession defJSSessionOpts $ \s -> do
+            () <- [expr| global.x = $buf |] s
+            (v :: JSVal) <- [expr| global.x |] s
+            [expr| $v |] s
+          result @?= buf
+      ]

--- a/inline-js/tests/Tests/Wasm.hs
+++ b/inline-js/tests/Tests/Wasm.hs
@@ -1,8 +1,9 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 module Tests.Wasm
-  ( tests
-  ) where
+  ( tests,
+  )
+where
 
 import Data.Aeson
 import qualified Data.ByteString.Lazy as LBS
@@ -23,19 +24,17 @@ tests :: IO TestTree
 tests = do
   datadir <- Paths_inline_js.getDataDir
   fib_buf <- LBS.readFile $ datadir </> "testdata" </> "fib.wasm"
-  pure $
-    testProperty "WebAssembly" $
-    over (generate $ const [1 .. 24]) $ \i ->
-      monadic $
-      withJSSession defJSSessionOpts $ \s -> do
-        buf_ref <- alloc s fib_buf
-        result_ref <-
-          eval s $ "WebAssembly.instantiate(" <> takeJSVal buf_ref <> ")"
-        fib_result_buf <-
-          eval s $
-          jsonStringify $
-          takeJSVal result_ref <> ".instance.exports.fib(" <>
-          fromString (show i) <>
-          ")"
-        closeJSSession s
-        pure $ eitherDecode' fib_result_buf == Right (fib i)
+  pure $ testProperty "WebAssembly" $ over (generate $ const [1 .. 24]) $ \i ->
+    monadic $ withJSSession defJSSessionOpts $ \s -> do
+      buf_ref <- alloc s fib_buf
+      result_ref <-
+        eval s $ "WebAssembly.instantiate(" <> takeJSVal buf_ref <> ")"
+      fib_result_buf <-
+        eval s
+          $ jsonStringify
+          $ takeJSVal result_ref
+            <> ".instance.exports.fib("
+            <> fromString (show i)
+            <> ")"
+      closeJSSession s
+      pure $ eitherDecode' fib_result_buf == Right (fib i)

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-14.7
+resolver: lts-14.11
 packages:
   - inline-js
   - inline-js-core


### PR DESCRIPTION
Following changes in `asterius`, we apply `ormolu` to existing Haskell code before further refactoring, and designate `ormolu` as our official formatter here.