### PR TITLE
Implement more graceful `closeJSSession`

### DIFF
--- a/inline-js-core/jsbits/eval.mjs
+++ b/inline-js-core/jsbits/eval.mjs
@@ -79,14 +79,15 @@ async function handleHostMessage(msg_buf) {
   }
 }
 
-const msg_len_buf = Buffer.allocUnsafe(4);
+const msg_len_buf = Buffer.allocUnsafe(4),
+  shutdown_buf = Buffer.from("SHUTDOWN");
 
 async function onHostMessage() {
   await pipeRead(node_read_fd, msg_len_buf, 4);
   const msg_len = msg_len_buf.readUInt32LE(0),
     msg_buf = Buffer.allocUnsafe(msg_len);
   await pipeRead(node_read_fd, msg_buf, msg_len);
-  setImmediate(onHostMessage);
+  if (!msg_buf.equals(shutdown_buf)) setImmediate(onHostMessage);
   setImmediate(handleHostMessage, msg_buf);
 }
 

--- a/inline-js-core/jsbits/eval.mjs
+++ b/inline-js-core/jsbits/eval.mjs
@@ -79,14 +79,15 @@ async function handleHostMessage(msg_buf) {
   }
 }
 
+const msg_len_buf = Buffer.allocUnsafe(4);
+
 async function onHostMessage() {
-  const msg_len_buf = Buffer.allocUnsafe(4);
-  await pipeRead(node_read_fd, msg_len_buf, 0, 4);
+  await pipeRead(node_read_fd, msg_len_buf, 4);
   const msg_len = msg_len_buf.readUInt32LE(0),
     msg_buf = Buffer.allocUnsafe(msg_len);
-  await pipeRead(node_read_fd, msg_buf, 0, msg_len);
-  setImmediate(handleHostMessage, msg_buf);
+  await pipeRead(node_read_fd, msg_buf, msg_len);
   setImmediate(onHostMessage);
+  setImmediate(handleHostMessage, msg_buf);
 }
 
 onHostMessage();

--- a/inline-js-core/jsbits/pipe.mjs
+++ b/inline-js-core/jsbits/pipe.mjs
@@ -7,14 +7,14 @@ const read_lock = new Lock(),
   read_func = util.promisify(fs.read),
   write_func = util.promisify(fs.write);
 
-export async function pipeRead(fd, buf, offset, length) {
+export async function pipeRead(fd, buf, length) {
   await read_lock.take();
   let total_bytes_read = 0;
   while (total_bytes_read < length) {
     const { bytesRead } = await read_func(
       fd,
       buf,
-      offset + total_bytes_read,
+      total_bytes_read,
       length - total_bytes_read,
       null
     );

--- a/inline-js-core/src/Language/JavaScript/Inline/Core/Session.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Core/Session.hs
@@ -147,7 +147,7 @@ newJSSession JSSessionOpts {..} = do
        in void $ tryAny w
   _msg_counter <- newMsgCounter
   _close <- once $ do
-    -- terminateProcess _ph
+    atomically $ writeTQueue send_queue "SHUTDOWN"
     case nodeWorkDir of
       Just p -> for_ mjss $ \mjs -> removeFile $ p </> mjs
       _ -> pure ()


### PR DESCRIPTION
Previously, we implement `closeJSSession` by forcibly terminating the send/recv threads and the `node` process. This approach works only when no send/recv action is ongoing, and seems to be the source of occasional broken pipe bugs. We now implement a more graceful `closeJSSession`:

* A special `SHUTDOWN` message is enqueued to be picked up and sent by the send thread.
* When the eval server receives `SHUTDOWN`, it no longer processes the next incoming message. When all messages are handled, the event queue will be empty, and `node` will shutdown gracefully.
* The infinite loop in the send/recv threads are wrapped with `tryAny`, so when `node` shuts down and the pipes are closed, the threads will silently exit instead of invoking an unhandled exception handler.

This shall also clarify the semantics of `closeJSSession` a bit. When it is invoked, we should still allow further responses from `node`, but disallow any further requests to `node`. Enforcing the second part takes more work and shall go in a separate PR.