### PR TITLE
A uniform exception type

### DIFF
--- a/inline-js-core/inline-js-core.cabal
+++ b/inline-js-core/inline-js-core.cabal
@@ -25,6 +25,7 @@ library
       Language.JavaScript.Inline.Core
   other-modules:
       Language.JavaScript.Inline.Core.Command
+      Language.JavaScript.Inline.Core.Exception
       Language.JavaScript.Inline.Core.Internal
       Language.JavaScript.Inline.Core.JSCode
       Language.JavaScript.Inline.Core.Message.Class

--- a/inline-js-core/src/Language/JavaScript/Inline/Core.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Core.hs
@@ -16,7 +16,7 @@ module Language.JavaScript.Inline.Core
     deRefJSVal,
     freeJSVal,
     takeJSVal,
-    EvalException (..),
+    InlineJSException (..),
     eval,
     alloc,
     importMJS,
@@ -27,6 +27,7 @@ module Language.JavaScript.Inline.Core
 where
 
 import Language.JavaScript.Inline.Core.Command
+import Language.JavaScript.Inline.Core.Exception
 import Language.JavaScript.Inline.Core.JSCode hiding
   ( importMJS,
   )

--- a/inline-js-core/src/Language/JavaScript/Inline/Core/Command.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Core/Command.hs
@@ -51,7 +51,6 @@ checkEvalResponse' = (>>= checkEvalResponse)
 -- 3. @()@, which indicates the code doesn't return anything (even if it does,
 --    the result is discarded)
 eval ::
-  forall r.
   (Request (EvalRequest r), Response (EvalResponse r)) =>
   JSSession ->
   JSCode ->

--- a/inline-js-core/src/Language/JavaScript/Inline/Core/Command.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Core/Command.hs
@@ -3,8 +3,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Language.JavaScript.Inline.Core.Command
-  ( EvalException (..),
-    eval,
+  ( eval,
     eval',
     alloc,
     alloc',
@@ -16,6 +15,7 @@ where
 import Control.Exception
 import Control.Monad
 import qualified Data.ByteString.Lazy as LBS
+import Language.JavaScript.Inline.Core.Exception
 import Language.JavaScript.Inline.Core.JSCode hiding
   ( importMJS,
   )
@@ -24,21 +24,10 @@ import Language.JavaScript.Inline.Core.Message.Class
 import Language.JavaScript.Inline.Core.Message.Eval
 import Language.JavaScript.Inline.Core.Session
 import System.Directory
-import Prelude
-
--- | The eval server may respond with an error message, in which case this
--- exception is raised.
-newtype EvalException
-  = EvalException
-      { evalErrorMessage :: LBS.ByteString
-      }
-  deriving (Show)
-
-instance Exception EvalException
 
 checkEvalResponse :: EvalResponse r -> IO r
 checkEvalResponse r = case r of
-  EvalError {..} -> throwIO EvalException {evalErrorMessage = evalError}
+  EvalError {..} -> throwIO EvalException {evalError = evalError}
   EvalResult {..} -> pure evalResult
 
 checkEvalResponse' :: IO (EvalResponse r) -> IO r

--- a/inline-js-core/src/Language/JavaScript/Inline/Core/Exception.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Core/Exception.hs
@@ -1,0 +1,24 @@
+{-# LANGUAGE StrictData #-}
+
+module Language.JavaScript.Inline.Core.Exception
+  ( InlineJSException (..),
+  )
+where
+
+import Control.Exception
+import qualified Data.ByteString.Lazy as LBS
+import Data.Version
+
+data InlineJSException
+  = UnsupportedNodeVersion
+      { detectedNodeVersion :: Version
+      }
+  | IllegalResponse
+      { illegalResponse :: LBS.ByteString
+      }
+  | EvalException
+      { evalError :: LBS.ByteString
+      }
+  deriving (Show)
+
+instance Exception InlineJSException

--- a/inline-js-core/src/Language/JavaScript/Inline/Core/Message/Class.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Core/Message/Class.hs
@@ -6,9 +6,11 @@ module Language.JavaScript.Inline.Core.Message.Class
   )
 where
 
+import Control.Exception
 import Data.Binary.Get
 import Data.Binary.Put
 import qualified Data.ByteString.Lazy as LBS
+import Language.JavaScript.Inline.Core.Exception
 import Language.JavaScript.Inline.Core.MessageCounter
 
 class Request r where
@@ -25,7 +27,4 @@ encodeRequest msg_id req = runPut $ do
 decodeResponse :: Response r => LBS.ByteString -> IO r
 decodeResponse buf = case runGetOrFail getResponse buf of
   Right (rest, _, resp) | LBS.null rest -> pure resp
-  _ ->
-    fail $
-      "Language.JavaScript.Inline.Core.Message.Class.decodeResponse: failed to decode message from "
-        <> show buf
+  _ -> throwIO IllegalResponse {illegalResponse = buf}

--- a/inline-js-core/src/Language/JavaScript/Inline/Core/NodeVersion.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Core/NodeVersion.hs
@@ -5,8 +5,10 @@ module Language.JavaScript.Inline.Core.NodeVersion
   )
 where
 
+import Control.Exception
 import Control.Monad
 import Data.Version
+import Language.JavaScript.Inline.Core.Exception
 import System.Process
 
 split :: (a -> Bool) -> [a] -> [[a]]
@@ -32,8 +34,5 @@ nodeVersion p = do
 checkNodeVersion :: FilePath -> IO ()
 checkNodeVersion p = do
   v <- nodeVersion p
-  unless (v >= Version [12, 2] [])
-    $ fail
-    $ "Detected node version "
-      <> show v
-      <> ", requires at least node 12.2"
+  unless (v >= Version [12, 2] []) $
+    throwIO UnsupportedNodeVersion {detectedNodeVersion = v}

--- a/inline-js-core/src/Language/JavaScript/Inline/Core/Session.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Core/Session.hs
@@ -174,12 +174,7 @@ newJSSession JSSessionOpts {..} = do
 withJSSession :: JSSessionOpts -> (JSSession -> IO r) -> IO r
 withJSSession opts = bracket (newJSSession opts) closeJSSession
 
-sendMsg ::
-  forall req resp.
-  (Request req, Response resp) =>
-  JSSession ->
-  req ->
-  IO (IO resp)
+sendMsg :: (Request req, Response resp) => JSSession -> req -> IO (IO resp)
 sendMsg JSSession {..} msg = do
   msg_id <- newMsgId msgCounter
   sendData $ encodeRequest msg_id msg


### PR DESCRIPTION
This PR introduces `InlineJSException` as the uniform type of exceptions to be handled by library users. Some previously ad hoc `fail` calls are replaced with the corresponding variant of `InlineJSException`.