### PR TITLE
Use CommonJS for jsbits in inline-js-core

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,9 +32,15 @@ jobs:
             stack --no-terminal test inline-js:inline-js-test-suite --test-arguments="-j2"
             rm -rf ~/node/*
 
-            node-fetcher --channel v8-canary --path ~/node --verbose
+            node-fetcher --channel nightly --path ~/node --verbose
             stack --no-terminal test inline-js:inline-js-test-suite --test-arguments="-j2"
             rm -rf ~/node/*
+
+            node-fetcher --channel v8-canary --path ~/node --verbose
+            stack --no-terminal test inline-js:inline-js-test-suite --test-arguments="-j2"
+
+            node-fetcher --channel v8 --path ~/node --verbose
+            stack --no-terminal test inline-js:inline-js-test-suite --test-arguments="-j2"
 
   inline-js-test-macos:
     macos:
@@ -70,9 +76,12 @@ jobs:
             stack --no-terminal test inline-js:inline-js-test-suite --test-arguments="-j2"
             rm -rf ~/node/*
 
-            node-fetcher --channel v8-canary --path ~/node --verbose
+            node-fetcher --channel nightly --path ~/node --verbose
             stack --no-terminal test inline-js:inline-js-test-suite --test-arguments="-j2"
             rm -rf ~/node/*
+
+            node-fetcher --channel v8-canary --path ~/node --verbose
+            stack --no-terminal test inline-js:inline-js-test-suite --test-arguments="-j2"
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,21 +20,19 @@ jobs:
 
             stack --no-terminal -j2 build --haddock --test --no-run-tests
 
-            node-fetcher --channel release --version v12 --path ~/node
-            node --version
-            npm --version
+            node-fetcher --channel release --version v10 --path ~/node --verbose
             stack --no-terminal test inline-js:inline-js-test-suite --test-arguments="-j2"
             rm -rf ~/node/*
 
-            node-fetcher --channel release --version v13 --path ~/node
-            node --version
-            npm --version
+            node-fetcher --channel release --version v12 --path ~/node --verbose
             stack --no-terminal test inline-js:inline-js-test-suite --test-arguments="-j2"
             rm -rf ~/node/*
 
-            node-fetcher --channel v8-canary --path ~/node
-            node --version
-            npm --version
+            node-fetcher --channel release --version v13 --path ~/node --verbose
+            stack --no-terminal test inline-js:inline-js-test-suite --test-arguments="-j2"
+            rm -rf ~/node/*
+
+            node-fetcher --channel v8-canary --path ~/node --verbose
             stack --no-terminal test inline-js:inline-js-test-suite --test-arguments="-j2"
             rm -rf ~/node/*
 
@@ -60,22 +58,20 @@ jobs:
 
             stack --no-terminal -j4 build --test --no-run-tests
 
-            node-fetcher --channel release --version v12 --path ~/node
-            node --version
-            npm --version
-            stack --no-terminal test inline-js:inline-js-test-suite --test-arguments="-j4"
+            node-fetcher --channel release --version v10 --path ~/node --verbose
+            stack --no-terminal test inline-js:inline-js-test-suite --test-arguments="-j2"
             rm -rf ~/node/*
 
-            node-fetcher --channel release --version v13 --path ~/node
-            node --version
-            npm --version
-            stack --no-terminal test inline-js:inline-js-test-suite --test-arguments="-j4"
+            node-fetcher --channel release --version v12 --path ~/node --verbose
+            stack --no-terminal test inline-js:inline-js-test-suite --test-arguments="-j2"
             rm -rf ~/node/*
 
-            node-fetcher --channel v8-canary --path ~/node
-            node --version
-            npm --version
-            stack --no-terminal test inline-js:inline-js-test-suite --test-arguments="-j4"
+            node-fetcher --channel release --version v13 --path ~/node --verbose
+            stack --no-terminal test inline-js:inline-js-test-suite --test-arguments="-j2"
+            rm -rf ~/node/*
+
+            node-fetcher --channel v8-canary --path ~/node --verbose
+            stack --no-terminal test inline-js:inline-js-test-suite --test-arguments="-j2"
             rm -rf ~/node/*
 
 workflows:

--- a/inline-js-core/inline-js-core.cabal
+++ b/inline-js-core/inline-js-core.cabal
@@ -14,7 +14,7 @@ extra-source-files:
     CHANGELOG.md
     LICENSE
 data-files:
-    jsbits/*.mjs
+    jsbits/*.js
 
 source-repository head
   type: git

--- a/inline-js-core/jsbits/eval.js
+++ b/inline-js-core/jsbits/eval.js
@@ -1,9 +1,7 @@
-import module from "module";
-import process from "process";
-import { StringDecoder } from "string_decoder";
-import vm from "vm";
-import JSVal from "./jsval.mjs";
-import { pipeRead, pipeWrite } from "./pipe.mjs";
+const { StringDecoder } = require("string_decoder"),
+  vm = require("vm"),
+  JSVal = require("./jsval.js"),
+  { pipeRead, pipeWrite } = require("./pipe.js");
 
 function errorStringify(err) {
   return err.stack ? err.stack : `${err}`;
@@ -25,7 +23,7 @@ function bufferFromU32(x) {
 }
 
 global.JSVal = JSVal;
-global.require = module.createRequire(import.meta.url);
+global.require = require;
 
 function postHostMessage(msg_id, is_err, result) {
   const result_buf = Buffer.from(result),

--- a/inline-js-core/jsbits/jsval.js
+++ b/inline-js-core/jsbits/jsval.js
@@ -36,4 +36,4 @@ class JSValManager {
   }
 }
 
-export default new JSValManager();
+module.exports = new JSValManager();

--- a/inline-js-core/jsbits/lock.js
+++ b/inline-js-core/jsbits/lock.js
@@ -15,7 +15,7 @@ function newNode() {
   return { promise: p, resolve: r, next: newThunk(newNode) };
 }
 
-export class Lock {
+exports.Lock = class {
   constructor() {
     this.takeNode = newNode();
     this.putNode = this.takeNode;
@@ -33,4 +33,4 @@ export class Lock {
     this.putNode.resolve();
     this.putNode = this.putNode.next();
   }
-}
+};

--- a/inline-js-core/jsbits/pipe.js
+++ b/inline-js-core/jsbits/pipe.js
@@ -1,13 +1,13 @@
-import fs from "fs";
-import util from "util";
-import { Lock } from "./lock.mjs";
+const fs = require("fs"),
+  util = require("util"),
+  { Lock } = require("./lock.js");
 
 const read_lock = new Lock(),
   write_lock = new Lock(),
   read_func = util.promisify(fs.read),
   write_func = util.promisify(fs.write);
 
-export async function pipeRead(fd, buf, length) {
+exports.pipeRead = async (fd, buf, length) => {
   await read_lock.take();
   let total_bytes_read = 0;
   while (total_bytes_read < length) {
@@ -21,9 +21,9 @@ export async function pipeRead(fd, buf, length) {
     total_bytes_read += bytesRead;
   }
   read_lock.put();
-}
+};
 
-export async function pipeWrite(fd, buf) {
+exports.pipeWrite = async (fd, buf) => {
   await write_lock.take();
   let total_bytes_written = 0;
   while (total_bytes_written < buf.length) {
@@ -37,4 +37,4 @@ export async function pipeWrite(fd, buf) {
     total_bytes_written += bytesWritten;
   }
   write_lock.put();
-}
+};

--- a/inline-js-core/src/Language/JavaScript/Inline/Core/JSCode.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Core/JSCode.hs
@@ -34,7 +34,9 @@ instance Show JSCode where
 -- | UTF-8 decode a @Buffer@ and return a @string@.
 bufferToString :: JSCode -> JSCode
 bufferToString expr =
-  "(new TextDecoder('utf-8', {fatal: true})).decode(" <> expr <> ")"
+  "(new (require('util').TextDecoder)('utf-8', {fatal: true})).decode("
+    <> expr
+    <> ")"
 
 -- | @JSON.parse()@ a @string@.
 jsonParse :: JSCode -> JSCode

--- a/inline-js-core/src/Language/JavaScript/Inline/Core/JSCode.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Core/JSCode.hs
@@ -49,9 +49,9 @@ jsonStringify expr = "JSON.stringify(" <> expr <> ")"
 importMJS :: FilePath -> JSCode
 importMJS p =
   coerce $
-    "import('url').then(url => url.pathToFileURL("
+    "import((new (require('url').URL)('file:///'+"
       <> stringUtf8 (show p)
-      <> ").href).then(url => import(url))"
+      <> ")).href)"
 
 -- | A reference to a JavaScript value.
 --

--- a/inline-js-core/src/Language/JavaScript/Inline/Core/NodeVersion.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Core/NodeVersion.hs
@@ -5,6 +5,7 @@ module Language.JavaScript.Inline.Core.NodeVersion
   )
 where
 
+import Control.DeepSeq
 import Control.Exception
 import Control.Monad
 import Data.Version
@@ -29,10 +30,10 @@ nodeVersion p = do
   ('v' : s) <- readProcess p ["--version"] ""
   let vs : tags = split (== '-') s
       v = map read $ split (== '.') vs
-  pure $ Version v tags
+  evaluate $ force $ Version v tags
 
 checkNodeVersion :: FilePath -> IO ()
 checkNodeVersion p = do
   v <- nodeVersion p
-  unless (v >= Version [12, 2] []) $
+  unless (v >= Version [10, 12] []) $
     throwIO UnsupportedNodeVersion {detectedNodeVersion = v}

--- a/inline-js-core/src/Language/JavaScript/Inline/Core/NodeVersion.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Core/NodeVersion.hs
@@ -35,5 +35,5 @@ nodeVersion p = do
 checkNodeVersion :: FilePath -> IO ()
 checkNodeVersion p = do
   v <- nodeVersion p
-  unless (v >= Version [10, 12] []) $
+  unless (v >= Version [10, 15, 3] []) $
     throwIO UnsupportedNodeVersion {detectedNodeVersion = v}

--- a/inline-js-core/src/Language/JavaScript/Inline/Core/Session.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Core/Session.hs
@@ -91,14 +91,14 @@ data JSSession
 newJSSession :: JSSessionOpts -> IO JSSession
 newJSSession JSSessionOpts {..} = do
   checkNodeVersion nodePath
-  (mjss_dir, mjss) <- do
-    mjss_dir <- (</> "jsbits") <$> Paths_inline_js_core.getDataDir
+  (jsbits_dir, jss) <- do
+    jsbits_dir <- (</> "jsbits") <$> Paths_inline_js_core.getDataDir
     case nodeWorkDir of
       Just p -> do
-        mjss <- listDirectory mjss_dir
-        for_ mjss $ \mjs -> copyFile (mjss_dir </> mjs) (p </> mjs)
-        pure (p, mjss)
-      _ -> pure (mjss_dir, [])
+        jss <- listDirectory jsbits_dir
+        for_ jss $ \js -> copyFile (jsbits_dir </> js) (p </> js)
+        pure (p, jss)
+      _ -> pure (jsbits_dir, [])
   parent_env <- getEnvironment
   (host_read_h, node_write_h) <- createPipe
   (node_read_h, host_write_h) <- createPipe
@@ -109,7 +109,7 @@ newJSSession JSSessionOpts {..} = do
       ( proc nodePath $
           nodeExtraArgs
             <> [ "--experimental-modules",
-                 mjss_dir </> "eval.mjs",
+                 jsbits_dir </> "eval.js",
                  show node_write_fd,
                  show node_read_fd
                ]
@@ -149,7 +149,7 @@ newJSSession JSSessionOpts {..} = do
   _close <- once $ do
     atomically $ writeTQueue send_queue "SHUTDOWN"
     case nodeWorkDir of
-      Just p -> for_ mjss $ \mjs -> removeFile $ p </> mjs
+      Just p -> for_ jss $ \js -> removeFile $ p </> js
       _ -> pure ()
   pure JSSession
     { closeJSSession = _close,


### PR DESCRIPTION
This PR uses CommonJS for `jsbits` in `inline-js-core`. This allows us to assign a global `require` directly using the `require` in the scope of `eval.js`, instead of using `module.createRequire`. The `node` version requirement is relaxed to `v10.15.3`.