### PR TITLE
Test cabal support on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2
 
 jobs:
-  inline-js-test-linux:
+  inline-js-test-linux-stack:
     docker:
       - image: terrorjack/stackage:lts-14.14
     steps:
@@ -42,7 +42,74 @@ jobs:
             node-fetcher --channel v8 --path ~/node --verbose
             stack --no-terminal test inline-js:inline-js-test-suite --test-arguments="-j2"
 
-  inline-js-test-macos:
+  inline-js-test-linux-cabal:
+    docker:
+      - image: ubuntu:eoan
+    environment:
+      - DEBIAN_FRONTEND: noninteractive
+      - LANG: C.UTF-8
+    steps:
+      - run:
+          name: Install dependencies
+          command: |
+            export PATH=~/.cabal/bin:~/.ghcup/bin:~/.local/bin:$PATH
+
+            apt update
+            apt full-upgrade -y
+            apt install -y \
+              build-essential \
+              curl \
+              git \
+              libffi-dev \
+              libgmp-dev \
+              libncurses-dev \
+              openssh-client \
+              python3-minimal
+
+            mkdir -p ~/.ghcup/bin
+            curl https://gitlab.haskell.org/haskell/ghcup/raw/master/ghcup -o ~/.ghcup/bin/ghcup
+            chmod u+x ~/.ghcup/bin/ghcup
+
+            ghcup install 8.8.1
+            ghcup set 8.8.1
+            ghcup install-cabal 3.0.0.0
+            cabal new-update
+
+            mkdir -p ~/.local/bin
+            curl -L https://raw.githubusercontent.com/TerrorJack/node-fetcher/master/node-fetcher.py -o ~/.local/bin/node-fetcher
+            chmod u+x ~/.local/bin/node-fetcher
+      - checkout
+      - run:
+          name: Test inline-js
+          command: |
+            mkdir ~/node
+            export PATH=~/.cabal/bin:~/.ghcup/bin:~/.local/bin:~/node/bin:$PATH
+
+            cabal new-build -j2 inline-js:inline-js-test-suite
+
+            node-fetcher --channel release --version v10 --path ~/node --verbose
+            cabal new-test -j2 inline-js:inline-js-test-suite -- -j2
+            rm -rf ~/node/*
+
+            node-fetcher --channel release --version v12 --path ~/node --verbose
+            cabal new-test -j2 inline-js:inline-js-test-suite -- -j2
+            rm -rf ~/node/*
+
+            node-fetcher --channel release --version v13 --path ~/node --verbose
+            cabal new-test -j2 inline-js:inline-js-test-suite -- -j2
+            rm -rf ~/node/*
+
+            node-fetcher --channel nightly --path ~/node --verbose
+            cabal new-test -j2 inline-js:inline-js-test-suite -- -j2
+            rm -rf ~/node/*
+
+            node-fetcher --channel v8-canary --path ~/node --verbose
+            cabal new-test -j2 inline-js:inline-js-test-suite -- -j2
+
+            node-fetcher --channel v8 --path ~/node --verbose
+            cabal new-test -j2 inline-js:inline-js-test-suite -- -j2
+
+  inline-js-test-macos-stack:
     macos:
       xcode: "11.2.0"
     steps:
@@ -87,5 +154,6 @@ workflows:
   version: 2
   build:
     jobs:
-      - inline-js-test-linux
-      - inline-js-test-macos
+      - inline-js-test-linux-stack
+      - inline-js-test-linux-cabal
+      - inline-js-test-macos-stack

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,23 +132,72 @@ jobs:
             stack --no-terminal -j4 build --test --no-run-tests
 
             node-fetcher --channel release --version v10 --path ~/node --verbose
-            stack --no-terminal test inline-js:inline-js-test-suite --test-arguments="-j2"
+            stack --no-terminal test inline-js:inline-js-test-suite --test-arguments="-j4"
             rm -rf ~/node/*
 
             node-fetcher --channel release --version v12 --path ~/node --verbose
-            stack --no-terminal test inline-js:inline-js-test-suite --test-arguments="-j2"
+            stack --no-terminal test inline-js:inline-js-test-suite --test-arguments="-j4"
             rm -rf ~/node/*
 
             node-fetcher --channel release --version v13 --path ~/node --verbose
-            stack --no-terminal test inline-js:inline-js-test-suite --test-arguments="-j2"
+            stack --no-terminal test inline-js:inline-js-test-suite --test-arguments="-j4"
             rm -rf ~/node/*
 
             node-fetcher --channel nightly --path ~/node --verbose
-            stack --no-terminal test inline-js:inline-js-test-suite --test-arguments="-j2"
+            stack --no-terminal test inline-js:inline-js-test-suite --test-arguments="-j4"
             rm -rf ~/node/*
 
             node-fetcher --channel v8-canary --path ~/node --verbose
-            stack --no-terminal test inline-js:inline-js-test-suite --test-arguments="-j2"
+            stack --no-terminal test inline-js:inline-js-test-suite --test-arguments="-j4"
+
+  inline-js-test-macos-cabal:
+    macos:
+      xcode: "11.2.0"
+    steps:
+      - run:
+          name: Install dependencies
+          command: |
+            export PATH=~/.cabal/bin:~/.ghcup/bin:~/.local/bin:$PATH
+
+            mkdir -p ~/.ghcup/bin
+            curl https://gitlab.haskell.org/haskell/ghcup/raw/master/ghcup -o ~/.ghcup/bin/ghcup
+            chmod u+x ~/.ghcup/bin/ghcup
+
+            ghcup install 8.8.1
+            ghcup set 8.8.1
+            ghcup install-cabal 3.0.0.0
+            cabal new-update
+
+            mkdir -p ~/.local/bin
+            curl -L https://raw.githubusercontent.com/TerrorJack/node-fetcher/master/node-fetcher.py -o ~/.local/bin/node-fetcher
+            chmod u+x ~/.local/bin/node-fetcher
+      - checkout
+      - run:
+          name: Test inline-js
+          command: |
+            mkdir ~/node
+            export PATH=~/.cabal/bin:~/.ghcup/bin:~/.local/bin:~/node/bin:$PATH
+
+            cabal new-build -j4 inline-js:inline-js-test-suite
+
+            node-fetcher --channel release --version v10 --path ~/node --verbose
+            cabal new-test -j4 inline-js:inline-js-test-suite -- -j4
+            rm -rf ~/node/*
+
+            node-fetcher --channel release --version v12 --path ~/node --verbose
+            cabal new-test -j4 inline-js:inline-js-test-suite -- -j4
+            rm -rf ~/node/*
+
+            node-fetcher --channel release --version v13 --path ~/node --verbose
+            cabal new-test -j4 inline-js:inline-js-test-suite -- -j4
+            rm -rf ~/node/*
+
+            node-fetcher --channel nightly --path ~/node --verbose
+            cabal new-test -j4 inline-js:inline-js-test-suite -- -j4
+            rm -rf ~/node/*
+
+            node-fetcher --channel v8-canary --path ~/node --verbose
+            cabal new-test -j4 inline-js:inline-js-test-suite -- -j4
 
 workflows:
   version: 2
@@ -157,3 +206,4 @@ workflows:
       - inline-js-test-linux-stack
       - inline-js-test-linux-cabal
       - inline-js-test-macos-stack
+      - inline-js-test-macos-cabal

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,26 +88,26 @@ jobs:
             cabal new-build -j2 inline-js:inline-js-test-suite
 
             node-fetcher --channel release --version v10 --path ~/node --verbose
-            cabal new-test inline-js:inline-js-test-suite -- -j2
+            cabal new-run inline-js:inline-js-test-suite -- -j2
             rm -rf ~/node/*
 
             node-fetcher --channel release --version v12 --path ~/node --verbose
-            cabal new-test inline-js:inline-js-test-suite -- -j2
+            cabal new-run inline-js:inline-js-test-suite -- -j2
             rm -rf ~/node/*
 
             node-fetcher --channel release --version v13 --path ~/node --verbose
-            cabal new-test inline-js:inline-js-test-suite -- -j2
+            cabal new-run inline-js:inline-js-test-suite -- -j2
             rm -rf ~/node/*
 
             node-fetcher --channel nightly --path ~/node --verbose
-            cabal new-test inline-js:inline-js-test-suite -- -j2
+            cabal new-run inline-js:inline-js-test-suite -- -j2
             rm -rf ~/node/*
 
             node-fetcher --channel v8-canary --path ~/node --verbose
-            cabal new-test inline-js:inline-js-test-suite -- -j2
+            cabal new-run inline-js:inline-js-test-suite -- -j2
 
             node-fetcher --channel v8 --path ~/node --verbose
-            cabal new-test inline-js:inline-js-test-suite -- -j2
+            cabal new-run inline-js:inline-js-test-suite -- -j2
 
   inline-js-test-macos-stack:
     macos:
@@ -181,23 +181,23 @@ jobs:
             cabal new-build -j4 inline-js:inline-js-test-suite
 
             node-fetcher --channel release --version v10 --path ~/node --verbose
-            cabal new-test inline-js:inline-js-test-suite -- -j4
+            cabal new-run inline-js:inline-js-test-suite -- -j4
             rm -rf ~/node/*
 
             node-fetcher --channel release --version v12 --path ~/node --verbose
-            cabal new-test inline-js:inline-js-test-suite -- -j4
+            cabal new-run inline-js:inline-js-test-suite -- -j4
             rm -rf ~/node/*
 
             node-fetcher --channel release --version v13 --path ~/node --verbose
-            cabal new-test inline-js:inline-js-test-suite -- -j4
+            cabal new-run inline-js:inline-js-test-suite -- -j4
             rm -rf ~/node/*
 
             node-fetcher --channel nightly --path ~/node --verbose
-            cabal new-test inline-js:inline-js-test-suite -- -j4
+            cabal new-run inline-js:inline-js-test-suite -- -j4
             rm -rf ~/node/*
 
             node-fetcher --channel v8-canary --path ~/node --verbose
-            cabal new-test inline-js:inline-js-test-suite -- -j4
+            cabal new-run inline-js:inline-js-test-suite -- -j4
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,26 +88,26 @@ jobs:
             cabal new-build -j2 inline-js:inline-js-test-suite
 
             node-fetcher --channel release --version v10 --path ~/node --verbose
-            cabal new-test -j2 inline-js:inline-js-test-suite -- -j2
+            cabal new-test inline-js:inline-js-test-suite -- -j2
             rm -rf ~/node/*
 
             node-fetcher --channel release --version v12 --path ~/node --verbose
-            cabal new-test -j2 inline-js:inline-js-test-suite -- -j2
+            cabal new-test inline-js:inline-js-test-suite -- -j2
             rm -rf ~/node/*
 
             node-fetcher --channel release --version v13 --path ~/node --verbose
-            cabal new-test -j2 inline-js:inline-js-test-suite -- -j2
+            cabal new-test inline-js:inline-js-test-suite -- -j2
             rm -rf ~/node/*
 
             node-fetcher --channel nightly --path ~/node --verbose
-            cabal new-test -j2 inline-js:inline-js-test-suite -- -j2
+            cabal new-test inline-js:inline-js-test-suite -- -j2
             rm -rf ~/node/*
 
             node-fetcher --channel v8-canary --path ~/node --verbose
-            cabal new-test -j2 inline-js:inline-js-test-suite -- -j2
+            cabal new-test inline-js:inline-js-test-suite -- -j2
 
             node-fetcher --channel v8 --path ~/node --verbose
-            cabal new-test -j2 inline-js:inline-js-test-suite -- -j2
+            cabal new-test inline-js:inline-js-test-suite -- -j2
 
   inline-js-test-macos-stack:
     macos:
@@ -181,23 +181,23 @@ jobs:
             cabal new-build -j4 inline-js:inline-js-test-suite
 
             node-fetcher --channel release --version v10 --path ~/node --verbose
-            cabal new-test -j4 inline-js:inline-js-test-suite -- -j4
+            cabal new-test inline-js:inline-js-test-suite -- -j4
             rm -rf ~/node/*
 
             node-fetcher --channel release --version v12 --path ~/node --verbose
-            cabal new-test -j4 inline-js:inline-js-test-suite -- -j4
+            cabal new-test inline-js:inline-js-test-suite -- -j4
             rm -rf ~/node/*
 
             node-fetcher --channel release --version v13 --path ~/node --verbose
-            cabal new-test -j4 inline-js:inline-js-test-suite -- -j4
+            cabal new-test inline-js:inline-js-test-suite -- -j4
             rm -rf ~/node/*
 
             node-fetcher --channel nightly --path ~/node --verbose
-            cabal new-test -j4 inline-js:inline-js-test-suite -- -j4
+            cabal new-test inline-js:inline-js-test-suite -- -j4
             rm -rf ~/node/*
 
             node-fetcher --channel v8-canary --path ~/node --verbose
-            cabal new-test -j4 inline-js:inline-js-test-suite -- -j4
+            cabal new-test inline-js:inline-js-test-suite -- -j4
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   inline-js-test-linux:
     docker:
-      - image: terrorjack/stackage:lts-14.13
+      - image: terrorjack/stackage:lts-14.14
     steps:
       - run:
           name: Install dependencies

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-14.13
+resolver: lts-14.14
 packages:
   - inline-js
   - inline-js-core


### PR DESCRIPTION
This PR adds jobs for building & testing with cabal for linux & darwin, using `ghcup` to set up the toolchain.