### PR TITLE
Use `ArrayBuffer` when marshaling Haskell ByteStrings

### DIFF
--- a/inline-js-core/jsbits/eval.js
+++ b/inline-js-core/jsbits/eval.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const { StringDecoder } = require("string_decoder"),
   vm = require("vm"),
   JSVal = require("./jsval.js"),

--- a/inline-js-core/jsbits/eval.js
+++ b/inline-js-core/jsbits/eval.js
@@ -67,7 +67,9 @@ async function handleHostMessage(msg_buf) {
         break;
       }
       case 1: {
-        postHostMessage(msg_id, false, bufferFromU32(JSVal.newJSVal(buf)));
+        const arr_buf = new ArrayBuffer(buf.length);
+        buf.copy(Buffer.from(arr_buf));
+        postHostMessage(msg_id, false, bufferFromU32(JSVal.newJSVal(arr_buf)));
         break;
       }
       default: {

--- a/inline-js-core/jsbits/jsval.js
+++ b/inline-js-core/jsbits/jsval.js
@@ -1,3 +1,5 @@
+"use strict";
+
 class JSValManager {
   constructor() {
     this.map = new Map([[0, null]]);

--- a/inline-js-core/jsbits/lock.js
+++ b/inline-js-core/jsbits/lock.js
@@ -1,3 +1,5 @@
+"use strict";
+
 function newThunk(f) {
   let t = () => {
     const r = f();

--- a/inline-js-core/jsbits/pipe.js
+++ b/inline-js-core/jsbits/pipe.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const fs = require("fs"),
   util = require("util"),
   { Lock } = require("./lock.js");

--- a/inline-js/src/Language/JavaScript/Inline/Class.hs
+++ b/inline-js/src/Language/JavaScript/Inline/Class.hs
@@ -12,7 +12,6 @@ where
 
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString as BS
-import qualified Data.ByteString.Base64 as BS
 import qualified Data.ByteString.Base64.Lazy as LBS
 import Data.ByteString.Builder
 import qualified Data.ByteString.Lazy as LBS
@@ -26,15 +25,14 @@ class ToJSCode a where
 
 instance ToJSCode BS.ByteString where
   {-# INLINE toJSCode #-}
-  toJSCode buf =
-    "Buffer.from('" <> coerce (byteString (BS.encode buf)) <> "', 'base64')"
+  toJSCode = toJSCode . LBS.fromStrict
 
 instance ToJSCode LBS.ByteString where
   {-# INLINE toJSCode #-}
   toJSCode buf =
-    "Buffer.from('"
+    "(s => { const buf = Buffer.from(s, 'base64'), arr_buf = new ArrayBuffer(buf.length); buf.copy(Buffer.from(arr_buf)); return arr_buf; })('"
       <> coerce (lazyByteString (LBS.encode buf))
-      <> "', 'base64')"
+      <> "')"
 
 instance ToJSCode SBS.ShortByteString where
   {-# INLINE toJSCode #-}


### PR DESCRIPTION
This PR uses `ArrayBuffer` as the JavaScript buffer type for `alloc` commands and the `ToJSCode` instances of `ByteString` types. There's some extra copying overhead for now, but the transition from `Buffer` to `ArrayBuffer` should be done sooner or later anyway, since `ArrayBuffer` works across node & browsers.