### PR TITLE
Implement `SessionClosed` exception

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,7 +111,7 @@ jobs:
 
   inline-js-test-macos-stack:
     macos:
-      xcode: "11.2.0"
+      xcode: "11.2.1"
     steps:
       - run:
           name: Install dependencies
@@ -152,7 +152,7 @@ jobs:
 
   inline-js-test-macos-cabal:
     macos:
-      xcode: "11.2.0"
+      xcode: "11.2.1"
     steps:
       - run:
           name: Install dependencies

--- a/inline-js-core/src/Language/JavaScript/Inline/Core.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Core.hs
@@ -12,7 +12,7 @@ module Language.JavaScript.Inline.Core
     bufferToString,
     jsonParse,
     jsonStringify,
-    JSVal (..),
+    JSVal,
     deRefJSVal,
     freeJSVal,
     takeJSVal,

--- a/inline-js-core/src/Language/JavaScript/Inline/Core/Exception.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Core/Exception.hs
@@ -19,6 +19,7 @@ data InlineJSException
   | EvalException
       { evalError :: LBS.ByteString
       }
+  | SessionClosed
   deriving (Show)
 
 instance Exception InlineJSException

--- a/inline-js-core/src/Language/JavaScript/Inline/Core/Session.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Core/Session.hs
@@ -173,6 +173,6 @@ sendMsg :: (Request req, Response resp) => JSSession -> req -> IO (IO resp)
 sendMsg JSSession {..} msg = do
   mv <- newEmptyMVar
   sp <- newStablePtr mv
-  sendData $ encodeRequest sp msg
+  sendData (encodeRequest sp msg) `onException` freeStablePtr sp
   once $
     takeMVar mv >>= decodeResponse


### PR DESCRIPTION
Previously, when the session is closed, the send/recv threads die, but the send/recv queues are still functional, so when a command is invoked, the message stays in the send queue, and the returned continuation will block indefinitely. We now implement a `SessionClosed` exception variant, so after a session is closed, further attempts to send messages will immediately throw.