### PR TITLE
Add a "debug mode"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   inline-js-test-linux-stack:
     docker:
-      - image: terrorjack/stackage:lts-14.15
+      - image: terrorjack/stackage:lts-14.16
     steps:
       - run:
           name: Install dependencies

--- a/inline-js-core/src/Language/JavaScript/Inline/Core/Session.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Core/Session.hs
@@ -24,6 +24,7 @@ import Control.Monad
 import Data.ByteString.Builder
 import qualified Data.ByteString.Lazy as LBS
 import Data.Foldable
+import Data.Maybe
 import Data.Word
 import Foreign.Ptr
 import Foreign.StablePtr
@@ -63,7 +64,7 @@ data JSSessionOpts
 {-# NOINLINE defJSSessionOpts #-}
 defJSSessionOpts :: JSSessionOpts
 defJSSessionOpts = unsafePerformIO $ do
-  _datadir <- Paths_inline_js_core.getDataDir
+  _debug <- isJust <$> getEnv "INLINE_JS_DEBUG"
   pure JSSessionOpts
     { nodePath = "node",
       nodeExtraArgs = [],
@@ -71,7 +72,7 @@ defJSSessionOpts = unsafePerformIO $ do
       nodeExtraEnv = [],
       nodeStdInInherit = False,
       nodeStdOutInherit = False,
-      nodeStdErrInherit = False
+      nodeStdErrInherit = _debug
     }
 
 -- | Represents an active @node@ process and related IPC states.

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-14.15
+resolver: lts-14.16
 packages:
   - inline-js-core
 nix:


### PR DESCRIPTION
When hacking on the host/node wire protocol and changing the eval server js code, we used to break stuff and need to regularly set `nodeStdErrInherit = True` in the test suite to see the `stderr` of the `node` process; now we'll just flip it on by default if `INLINE_JS_DEBUG` environment variable is present. Also, a resolver bump sneaks in.