### PR TITLE
SIGKILL myself upon unhandledRejection events

### DIFF
--- a/inline-js-core/jsbits/eval.js
+++ b/inline-js-core/jsbits/eval.js
@@ -15,6 +15,12 @@ process.on("unhandledRejection", err => {
   });
 });
 
+process.on("uncaughtException", err => {
+  process.stderr.write(errorStringify(err), () => {
+    process.kill(process.pid, "SIGKILL");
+  });
+});
+
 const decoder = new StringDecoder("utf8"),
   node_read_fd = Number.parseInt(process.argv[process.argv.length - 1]),
   node_write_fd = Number.parseInt(process.argv[process.argv.length - 2]);

--- a/inline-js-core/jsbits/eval.js
+++ b/inline-js-core/jsbits/eval.js
@@ -10,8 +10,9 @@ function errorStringify(err) {
 }
 
 process.on("unhandledRejection", err => {
-  process.stderr.write(errorStringify(err));
-  throw err;
+  process.stderr.write(errorStringify(err), () => {
+    process.kill(process.pid, "SIGKILL");
+  });
 });
 
 const decoder = new StringDecoder("utf8"),


### PR DESCRIPTION
Our `unhandledRejection` handler in `eval.js` writes the error to `stderr` then rethrows it as an (uncaught) exception. It seems the `node` process doesn't exit when the asterius TH runner crashes, resulting in infinite blocking of `ahc`. Oddly even `process.exit(1)` won't exit `node`, so here we do a simple hack of suiciding the `node` process by sending itself a `SIGKILL`.

This PR isn't supposed to be merged; we should investigate the problem further: does this only occur with asterius TH runner, or all regular eval commands? How do we properly handle this kind of error in `inline-js-core`, rethrowing the error message in Haskell while avoiding infinite blocking?