### PR TITLE
Remove unneeded INLINE_JS_ROOT environment variable

### DIFF
--- a/inline-js-core/jsbits/index.js
+++ b/inline-js-core/jsbits/index.js
@@ -90,7 +90,7 @@ class WorkerContext {
       if (process.env.INLINE_JS_NODE_MODULES) {
         await fs.symlink(
           process.env.INLINE_JS_NODE_MODULES,
-          path.join(process.env.INLINE_JS_ROOT, "node_modules"),
+          path.join(__dirname, "node_modules"),
           "dir"
         );
       }

--- a/inline-js-core/src/Language/JavaScript/Inline/Core/Session.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Core/Session.hs
@@ -99,7 +99,6 @@ newSession Config {..} = do
               kvDedup $
                 [("INLINE_JS_EXIT_ON_EVAL_ERROR", "1") | nodeExitOnEvalError]
                   <> map ("INLINE_JS_NODE_MODULES",) (maybeToList nodeModules)
-                  <> [("INLINE_JS_ROOT", _root)]
                   <> nodeExtraEnv
                   <> _env,
           std_in = CreatePipe,


### PR DESCRIPTION
The root directory can be inferred from `__dirname` directly.