### PR TITLE
Fix sdist tarballs

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -159,18 +159,15 @@ jobs:
           mkdir $HOME/.node
           export PATH=$HOME/.local/bin:$HOME/.node/bin:$PATH
 
-          apk update
-          apk upgrade
           apk add \
             alpine-sdk \
             autoconf \
             bash \
             coreutils \
             gmp-dev \
+            grep \
             libffi-dev \
             ncurses-dev \
-            numactl-dev \
-            perl \
             xz
           ln -s /usr/lib/libncursesw.so.6 /usr/lib/libtinfow.so.6
 

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -199,6 +199,35 @@ jobs:
           node --version
           stack test inline-js-core:inline-js-core-tests --test-arguments="-j2"
 
+  sdist:
+    name: sdist
+    runs-on: ubuntu-20.04
+    steps:
+
+      - name: setup-haskell
+        uses: actions/setup-haskell@v1
+        with:
+          ghc-version: 8.10.1
+          cabal-version: 3.2.0.0
+
+      - name: checkout
+        uses: actions/checkout@v2
+
+      - name: sdist
+        run: |
+          pushd inline-js-core
+          cabal check
+          popd
+
+          cabal v2-sdist \
+            inline-js-core
+
+      - name: upload-artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: inline-js-core-0.0.1.0.tar.gz
+          path: dist-newstyle/sdist/inline-js-core-0.0.1.0.tar.gz
+
   haddock:
     name: haddock
     runs-on: ubuntu-20.04
@@ -225,7 +254,7 @@ jobs:
       - name: upload-artifact
         uses: actions/upload-artifact@v2
         with:
-          name: inline-js-core-0.0.1.0-docs
+          name: inline-js-core-0.0.1.0-docs.tar.gz
           path: dist-newstyle/inline-js-core-0.0.1.0-docs.tar.gz
 
   docs:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -199,8 +199,8 @@ jobs:
           node --version
           stack test inline-js-core:inline-js-core-tests --test-arguments="-j2"
 
-  haddock-hackage:
-    name: haddock-hackage
+  haddock:
+    name: haddock
     runs-on: ubuntu-20.04
     steps:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # `inline-js`: Call JavaScript from Haskell
 
-![](https://github.com/tweag/inline-js/workflows/pipeline/badge.svg?branch=master)
+[![GitHub Actions](https://github.com/tweag/inline-js/workflows/pipeline/badge.svg?branch=master)](https://github.com/tweag/inline-js/actions?query=branch%3Amaster)
 [![Gitter](https://img.shields.io/gitter/room/tweag/inline-js)](https://gitter.im/tweag/inline-js)
 
 ## Implemented features

--- a/inline-js-core/inline-js-core.cabal
+++ b/inline-js-core/inline-js-core.cabal
@@ -4,12 +4,13 @@ cabal-version: 2.2
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 8516903dd60ba2ebdcc93a2e2a3e0f8c8d0e8d9ae7c6348e914608d7ae8d8569
+-- hash: 02aeb3f49461b01f750ff2022b9e07acdd6cc99e52b335d87da9ba6ae40616ca
 
 name:           inline-js-core
 version:        0.0.1.0
+synopsis:       Call JavaScript from Haskell.
+description:    Please see <https://github.com/tweag/inline-js> for details.
 category:       Web
-stability:      alpha
 homepage:       https://github.com/tweag/inline-js#readme
 bug-reports:    https://github.com/tweag/inline-js/issues
 maintainer:     Shao Cheng <cheng.shao@tweag.io>
@@ -40,12 +41,14 @@ library
       Language.JavaScript.Inline.Core.Session
       Language.JavaScript.Inline.Core.Utils
       Paths_inline_js_core
+  autogen-modules:
+      Paths_inline_js_core
   hs-source-dirs:
       src
   ghc-options: -Wall
   build-depends:
       Cabal
-    , base
+    , base >=4.13 && <5
     , binary
     , bytestring
     , containers
@@ -67,7 +70,7 @@ test-suite inline-js-core-tests
   ghc-options: -Wall -threaded -rtsopts
   build-depends:
       Cabal
-    , base
+    , base >=4.13 && <5
     , binary
     , bytestring
     , containers

--- a/inline-js-core/package.yaml
+++ b/inline-js-core/package.yaml
@@ -1,11 +1,12 @@
 name: inline-js-core
 version: 0.0.1.0
 category: Web
-stability: alpha
 maintainer: Shao Cheng <cheng.shao@tweag.io>
 copyright: (c) 2018 Tweag I/O
 license: BSD-3-Clause
 github: tweag/inline-js
+synopsis: Call JavaScript from Haskell.
+description: Please see <https://github.com/tweag/inline-js> for details.
 
 extra-source-files:
   - jsbits/**
@@ -17,7 +18,7 @@ ghc-options: -Wall
 
 dependencies:
   - Cabal
-  - base
+  - base >= 4.13 && < 5
   - binary
   - bytestring
   - containers
@@ -30,6 +31,8 @@ dependencies:
 
 library:
   source-dirs: src
+  generated-other-modules:
+    - Paths_inline_js_core
   exposed-modules:
     - Language.JavaScript.Inline.Core
 


### PR DESCRIPTION
Minor fixes in the package metadata to conform to the hackage standard, and produce sdist tarballs on CI; also runs `cabal check` to prevent regression here.