### PR TITLE
API & docs adjustments

### DIFF
--- a/inline-js-core/src/Language/JavaScript/Inline/Core.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Core.hs
@@ -9,7 +9,7 @@ module Language.JavaScript.Inline.Core
     closeSession,
 
     -- * Evaluation requests
-    JSCode,
+    JSExpr,
     JSVal,
     code,
     buffer,
@@ -44,27 +44,27 @@ import Language.JavaScript.Inline.Core.Message hiding
 import Language.JavaScript.Inline.Core.Session
 import System.Directory
 
--- | Convert a 'String' to 'JSCode'. In most cases, using the 'IsString'
+-- | Convert a 'String' to 'JSExpr'. In most cases, using the 'IsString'
 -- instance with the @OverloadedStrings@ extension is more convenient.
-code :: String -> JSCode
+code :: String -> JSExpr
 code = fromString
 
 -- | Embed a 'LBS.ByteString' as a @Buffer@ expression.
-buffer :: LBS.ByteString -> JSCode
-buffer = JSCode . pure . BufferLiteral
+buffer :: LBS.ByteString -> JSExpr
+buffer = JSExpr . pure . BufferLiteral
 
 -- | Embed a 'String' as a @string@ expression.
-string :: String -> JSCode
-string = JSCode . pure . StringLiteral
+string :: String -> JSExpr
+string = JSExpr . pure . StringLiteral
 
 -- | Embed a UTF-8 encoded JSON expression. It will be parsed with
 -- @JSON.parse()@.
-json :: LBS.ByteString -> JSCode
-json = JSCode . pure . JSONLiteral
+json :: LBS.ByteString -> JSExpr
+json = JSExpr . pure . JSONLiteral
 
 -- | Embed a 'JSVal' as an expression.
-jsval :: JSVal -> JSCode
-jsval = JSCode . pure . JSValLiteral
+jsval :: JSVal -> JSExpr
+jsval = JSExpr . pure . JSValLiteral
 
 -- $notes-eval
 --

--- a/inline-js-core/src/Language/JavaScript/Inline/Core/IPC.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Core/IPC.hs
@@ -35,8 +35,8 @@ data IPC = IPC
 instance Show IPC where
   show IPC {} = "IPC"
 
--- | Given the 'Handle's for send/recv, this function adds the
--- 'send'/'recv'/'preClose' fields to an 'IPC' value.
+-- | Given the 'Handle's for send/recv, this function adds the 'send' / 'recv' /
+-- 'preClose' fields to an 'IPC' value.
 --
 -- The protocol for preserving message boundaries is simple: first comes the
 -- message header, which is just a little-endian 64-bit unsigned integer,
@@ -60,7 +60,7 @@ ipcFromHandles h_send h_recv ipc =
     }
 
 -- | This function forks the send/recv threads. In the result 'IPC' value, only
--- the 'send'/'closeMsg' fields remain valid and can be used by the user.
+-- the 'send' / 'closeMsg' fields remain valid and can be used by the user.
 --
 -- The send thread repeatedly fetches 'Msg's from a 'Channel' and send to the
 -- remote device; when the 'closeMsg' message is sent, it invokes the 'preClose'

--- a/inline-js-core/src/Language/JavaScript/Inline/Core/Instruction.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Core/Instruction.hs
@@ -23,7 +23,7 @@ evalWithDecoder ::
   JSReturnType ->
   (Session -> LBS.ByteString -> IO a) ->
   Session ->
-  JSCode ->
+  JSExpr ->
   IO a
 evalWithDecoder _return_type _decoder _session@Session {..} _code =
   do
@@ -55,25 +55,25 @@ evalWithDecoder _return_type _decoder _session@Session {..} _code =
         Left (SomeException _err) -> throwIO _err
         Right _result -> pure _result
 
--- | Evaluates a 'JSCode' and discards the evaluation result.
-evalNone :: Session -> JSCode -> IO ()
+-- | Evaluates a 'JSExpr' and discards the evaluation result.
+evalNone :: Session -> JSExpr -> IO ()
 evalNone = evalWithDecoder ReturnNone $ \_ _ -> pure ()
 
--- | Evaluates a 'JSCode' to a 'LBS.ByteString'. The evaluation result should be
+-- | Evaluates a 'JSExpr' to a 'LBS.ByteString'. The evaluation result should be
 -- an @ArrayBufferView@(@Buffer@, @TypedArray@ or @DataView@) or @ArrayBuffer@.
 -- It can also be a @string@, in which case the UTF-8 encoded result is
 -- returned. Other JavaScript types will result in an 'EvalError'.
-evalBuffer :: Session -> JSCode -> IO LBS.ByteString
+evalBuffer :: Session -> JSExpr -> IO LBS.ByteString
 evalBuffer = evalWithDecoder ReturnBuffer $ \_ _result_buf -> pure _result_buf
 
--- | Evaluate a 'JSCode', call @JSON.stringify()@ on the evaluation result and
+-- | Evaluate a 'JSExpr', call @JSON.stringify()@ on the evaluation result and
 -- return the UTF-8 encoded result.
-evalJSON :: Session -> JSCode -> IO LBS.ByteString
+evalJSON :: Session -> JSExpr -> IO LBS.ByteString
 evalJSON = evalWithDecoder ReturnJSON $ \_ _result_buf -> pure _result_buf
 
--- | Evaluates a 'JSCode' to a 'JSVal'. The evaluation result can be of any
+-- | Evaluates a 'JSExpr' to a 'JSVal'. The evaluation result can be of any
 -- JavaScript type.
-evalJSVal :: Session -> JSCode -> IO JSVal
+evalJSVal :: Session -> JSExpr -> IO JSVal
 evalJSVal = evalWithDecoder ReturnJSVal $ \_session _jsval_id_buf -> do
   _jsval_id <- runGetExact getWord64host _jsval_id_buf
   newJSVal _jsval_id (sessionSend _session $ JSValFree _jsval_id)

--- a/inline-js-core/src/Language/JavaScript/Inline/Core/JSVal.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Core/JSVal.hs
@@ -13,13 +13,13 @@ import GHC.Types
 -- Lifecycle of a 'JSVal':
 --   1. If the 'returnType' is specified as 'ReturnJSVal', the eval server makes
 --      a new 'JSVal' out of the return value and sends it back.
---   2. The 'JSVal' values can be passed around and later put into a 'JSCode'
+--   2. The 'JSVal' values can be passed around and later put into a 'JSExpr'
 --      for evaluation.
 --   3. When a 'JSVal' is garbage collected on the client side, the finalizer is
 --      called which frees it on the eval server side.
 --
 -- Notes to keep in mind:
---   1. When putting 'JSVal's into a 'JSCode', ensure the value is used
+--   1. When putting 'JSVal's into a 'JSExpr', ensure the value is used
 --      synchronously, as opposed to being used in the function body of a
 --      callback. Otherwise, by the time it's actually used, it may have already
 --      been freed.

--- a/inline-js-core/src/Language/JavaScript/Inline/Core/Message.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Core/Message.hs
@@ -68,14 +68,14 @@ messageHSPut msg = case msg of
     word8Put 0
       <> word64Put requestId
       <> word64Put (fromIntegral (NE.length (unJSExpr code)) :: Word64)
-      <> foldMap' codeSegmentPut (unJSExpr code)
+      <> foldMap' exprSegmentPut (unJSExpr code)
       <> returnTypePut returnType
     where
-      codeSegmentPut (Code s) = word8Put 0 <> lbsPut (stringToLBS s)
-      codeSegmentPut (BufferLiteral s) = word8Put 1 <> lbsPut s
-      codeSegmentPut (StringLiteral s) = word8Put 2 <> lbsPut (stringToLBS s)
-      codeSegmentPut (JSONLiteral s) = word8Put 3 <> lbsPut s
-      codeSegmentPut (JSValLiteral v) =
+      exprSegmentPut (Code s) = word8Put 0 <> lbsPut (stringToLBS s)
+      exprSegmentPut (BufferLiteral s) = word8Put 1 <> lbsPut s
+      exprSegmentPut (StringLiteral s) = word8Put 2 <> lbsPut (stringToLBS s)
+      exprSegmentPut (JSONLiteral s) = word8Put 3 <> lbsPut s
+      exprSegmentPut (JSValLiteral v) =
         word8Put 4 <> word64Put (unsafeUseJSVal v)
       returnTypePut ReturnNone = word8Put 0
       returnTypePut ReturnBuffer = word8Put 1

--- a/inline-js/src/Language/JavaScript/Inline.hs
+++ b/inline-js/src/Language/JavaScript/Inline.hs
@@ -6,6 +6,7 @@ module Language.JavaScript.Inline
     ToJS (..),
     FromJS (..),
     Aeson (..),
+    EncodedJSON (..),
 
     -- * Polymorphic eval function
     eval,

--- a/inline-js/src/Language/JavaScript/Inline.hs
+++ b/inline-js/src/Language/JavaScript/Inline.hs
@@ -4,7 +4,7 @@ module Language.JavaScript.Inline
 
     -- * Haskell/JavaScript data marshaling type classes
     ToJS (..),
-    FromEvalResult (..),
+    FromJS (..),
     Aeson (..),
 
     -- * Polymorphic eval function

--- a/inline-js/src/Language/JavaScript/Inline.hs
+++ b/inline-js/src/Language/JavaScript/Inline.hs
@@ -3,7 +3,7 @@ module Language.JavaScript.Inline
     module Language.JavaScript.Inline.Core,
 
     -- * Haskell/JavaScript data marshaling type classes
-    ToJSExpr (..),
+    ToJS (..),
     FromEvalResult (..),
     Aeson (..),
 

--- a/inline-js/src/Language/JavaScript/Inline.hs
+++ b/inline-js/src/Language/JavaScript/Inline.hs
@@ -3,7 +3,7 @@ module Language.JavaScript.Inline
     module Language.JavaScript.Inline.Core,
 
     -- * Haskell/JavaScript data marshaling type classes
-    ToJSCode (..),
+    ToJSExpr (..),
     FromEvalResult (..),
     Aeson (..),
 

--- a/inline-js/src/Language/JavaScript/Inline/Class.hs
+++ b/inline-js/src/Language/JavaScript/Inline/Class.hs
@@ -14,29 +14,29 @@ import Language.JavaScript.Inline.Core
 import System.IO.Unsafe
 
 -- | If a Haskell type @a@ has 'A.ToJSON'/'A.FromJSON' instances, then @Aeson a@
--- has 'ToJSExpr'/'FromEvalResult' instances. We can generate
--- 'ToJSExpr'/'FromEvalResult' instances for type @a@ via:
+-- has 'ToJS'/'FromEvalResult' instances. We can generate
+-- 'ToJS'/'FromEvalResult' instances for type @a@ via:
 --
--- 1. @deriving (ToJSExpr, FromEvalResult) via (Aeson a)@, using the
---    @DerivingVia@ extension
--- 2. @deriving (ToJSExpr, FromEvalResult)@, using the
---    @GeneralizedNewtypeDeriving@ extension
+-- 1. @deriving (ToJS, FromEvalResult) via (Aeson a)@, using the @DerivingVia@
+--    extension
+-- 2. @deriving (ToJS, FromEvalResult)@, using the @GeneralizedNewtypeDeriving@
+--    extension
 newtype Aeson a = Aeson
   { unAeson :: a
   }
 
 -- | To embed a Haskell value into a 'JSExpr', its type should be an instance of
--- 'ToJSExpr'.
-class ToJSExpr a where
+-- 'ToJS'.
+class ToJS a where
   toJSExpr :: a -> JSExpr
 
-instance ToJSExpr LBS.ByteString where
+instance ToJS LBS.ByteString where
   toJSExpr = buffer
 
-instance A.ToJSON a => ToJSExpr (Aeson a) where
+instance A.ToJSON a => ToJS (Aeson a) where
   toJSExpr = json . A.encode . unAeson
 
-instance ToJSExpr JSVal where
+instance ToJS JSVal where
   toJSExpr = jsval
 
 class RawEval a where

--- a/inline-js/src/Language/JavaScript/Inline/Class.hs
+++ b/inline-js/src/Language/JavaScript/Inline/Class.hs
@@ -49,7 +49,9 @@ instance RawFromJS LBS.ByteString where
   rawEval = evalBuffer
 
 -- | UTF-8 encoded JSON.
-newtype EncodedJSON = EncodedJSON LBS.ByteString
+newtype EncodedJSON = EncodedJSON
+  { unEncodedJSON :: LBS.ByteString
+  }
 
 instance RawFromJS EncodedJSON where
   rawEval = coerce evalJSON
@@ -87,6 +89,11 @@ instance FromJS () where
 
 instance FromJS LBS.ByteString where
   type RawJSType LBS.ByteString = LBS.ByteString
+  toRawJSType _ = "a => a"
+  fromRawJSType = pure
+
+instance FromJS EncodedJSON where
+  type RawJSType EncodedJSON = EncodedJSON
   toRawJSType _ = "a => a"
   fromRawJSType = pure
 

--- a/inline-js/src/Language/JavaScript/Inline/Class.hs
+++ b/inline-js/src/Language/JavaScript/Inline/Class.hs
@@ -38,22 +38,22 @@ instance A.ToJSON a => ToJS (Aeson a) where
 instance ToJS JSVal where
   toJS = jsval
 
-class RawEval a where
+class RawFromJS a where
   rawEval :: Session -> JSExpr -> IO a
 
-instance RawEval () where
+instance RawFromJS () where
   rawEval = evalNone
 
-instance RawEval LBS.ByteString where
+instance RawFromJS LBS.ByteString where
   rawEval = evalBuffer
 
-instance RawEval JSVal where
+instance RawFromJS JSVal where
   rawEval = evalJSVal
 
 -- | To decode a Haskell value from an eval result, its type should be an
 -- instance of 'FromJS'.
 class
-  (RawEval (EvalResult a)) =>
+  (RawFromJS (EvalResult a)) =>
   FromJS a
   where
   -- | The raw result type, must be one of '()', 'LBS.ByteString' or 'JSVal'.

--- a/inline-js/src/Language/JavaScript/Inline/Class.hs
+++ b/inline-js/src/Language/JavaScript/Inline/Class.hs
@@ -63,29 +63,29 @@ class
   toRawJSType :: Proxy a -> JSExpr
 
   -- | The Haskell function which decodes from the raw result.
-  fromJS :: RawJSType a -> IO a
+  fromRawJSType :: RawJSType a -> IO a
 
 instance FromJS () where
   type RawJSType () = ()
   toRawJSType _ = "a => a"
-  fromJS = pure
+  fromRawJSType = pure
 
 instance FromJS LBS.ByteString where
   type RawJSType LBS.ByteString = LBS.ByteString
   toRawJSType _ = "a => a"
-  fromJS = pure
+  fromRawJSType = pure
 
 instance A.FromJSON a => FromJS (Aeson a) where
   type RawJSType (Aeson a) = LBS.ByteString
   toRawJSType _ = "a => Buffer.from(JSON.stringify(a))"
-  fromJS s = case A.eitherDecode' s of
+  fromRawJSType s = case A.eitherDecode' s of
     Left err -> fail err
     Right a -> pure $ Aeson a
 
 instance FromJS JSVal where
   type RawJSType JSVal = JSVal
   toRawJSType _ = "a => a"
-  fromJS = pure
+  fromRawJSType = pure
 
 -- | The polymorphic eval function. Similar to the eval functions in
 -- "Language.JavaScript.Inline.Core", 'eval' performs /asynchronous/ evaluation
@@ -100,4 +100,4 @@ eval s c = do
         <> ").then("
         <> toRawJSType (Proxy @a)
         <> ")"
-  unsafeInterleaveIO $ fromJS =<< evaluate r
+  unsafeInterleaveIO $ fromRawJSType =<< evaluate r

--- a/inline-js/src/Language/JavaScript/Inline/Class.hs
+++ b/inline-js/src/Language/JavaScript/Inline/Class.hs
@@ -14,9 +14,8 @@ import Data.Proxy
 import Language.JavaScript.Inline.Core
 import System.IO.Unsafe
 
--- | If a Haskell type @a@ has 'A.ToJSON' / 'A.FromJSON' instances, then @Aeson
--- a@ has 'ToJS' / 'FromJS' instances. We can generate 'ToJS' / 'FromJS'
--- instances for type @a@ via:
+-- | If a Haskell type @a@ has 'A.ToJSON' and 'A.FromJSON' instances, then we
+-- can derive 'ToJS' and 'FromJS' instances for it using:
 --
 -- 1. @deriving (ToJS, FromJS) via (Aeson a)@, using the @DerivingVia@ extension
 -- 2. @deriving (ToJS, FromJS)@, using the @GeneralizedNewtypeDeriving@

--- a/inline-js/src/Language/JavaScript/Inline/Class.hs
+++ b/inline-js/src/Language/JavaScript/Inline/Class.hs
@@ -14,9 +14,9 @@ import Data.Proxy
 import Language.JavaScript.Inline.Core
 import System.IO.Unsafe
 
--- | If a Haskell type @a@ has 'A.ToJSON'/'A.FromJSON' instances, then @Aeson a@
--- has 'ToJS'/'FromJS' instances. We can generate 'ToJS'/'FromJS' instances for
--- type @a@ via:
+-- | If a Haskell type @a@ has 'A.ToJSON' / 'A.FromJSON' instances, then @Aeson
+-- a@ has 'ToJS' / 'FromJS' instances. We can generate 'ToJS' / 'FromJS'
+-- instances for type @a@ via:
 --
 -- 1. @deriving (ToJS, FromJS) via (Aeson a)@, using the @DerivingVia@ extension
 -- 2. @deriving (ToJS, FromJS)@, using the @GeneralizedNewtypeDeriving@

--- a/inline-js/src/Language/JavaScript/Inline/Class.hs
+++ b/inline-js/src/Language/JavaScript/Inline/Class.hs
@@ -63,29 +63,29 @@ class
   toEvalResult :: Proxy a -> JSExpr
 
   -- | The Haskell function which decodes from the raw result.
-  fromEvalResult :: EvalResult a -> IO a
+  fromJS :: EvalResult a -> IO a
 
 instance FromJS () where
   type EvalResult () = ()
   toEvalResult _ = "a => a"
-  fromEvalResult = pure
+  fromJS = pure
 
 instance FromJS LBS.ByteString where
   type EvalResult LBS.ByteString = LBS.ByteString
   toEvalResult _ = "a => a"
-  fromEvalResult = pure
+  fromJS = pure
 
 instance A.FromJSON a => FromJS (Aeson a) where
   type EvalResult (Aeson a) = LBS.ByteString
   toEvalResult _ = "a => Buffer.from(JSON.stringify(a))"
-  fromEvalResult s = case A.eitherDecode' s of
+  fromJS s = case A.eitherDecode' s of
     Left err -> fail err
     Right a -> pure $ Aeson a
 
 instance FromJS JSVal where
   type EvalResult JSVal = JSVal
   toEvalResult _ = "a => a"
-  fromEvalResult = pure
+  fromJS = pure
 
 -- | The polymorphic eval function. Similar to the eval functions in
 -- "Language.JavaScript.Inline.Core", 'eval' performs /asynchronous/ evaluation
@@ -100,4 +100,4 @@ eval s c = do
         <> ").then("
         <> toEvalResult (Proxy @a)
         <> ")"
-  unsafeInterleaveIO $ fromEvalResult =<< evaluate r
+  unsafeInterleaveIO $ fromJS =<< evaluate r

--- a/inline-js/src/Language/JavaScript/Inline/Class.hs
+++ b/inline-js/src/Language/JavaScript/Inline/Class.hs
@@ -28,16 +28,16 @@ newtype Aeson a = Aeson
 -- | To embed a Haskell value into a 'JSExpr', its type should be an instance of
 -- 'ToJS'.
 class ToJS a where
-  toJSExpr :: a -> JSExpr
+  toJS :: a -> JSExpr
 
 instance ToJS LBS.ByteString where
-  toJSExpr = buffer
+  toJS = buffer
 
 instance A.ToJSON a => ToJS (Aeson a) where
-  toJSExpr = json . A.encode . unAeson
+  toJS = json . A.encode . unAeson
 
 instance ToJS JSVal where
-  toJSExpr = jsval
+  toJS = jsval
 
 class RawEval a where
   rawEval :: Session -> JSExpr -> IO a

--- a/inline-js/src/Language/JavaScript/Inline/TH.hs
+++ b/inline-js/src/Language/JavaScript/Inline/TH.hs
@@ -46,7 +46,7 @@ blockQuoter js_code = do
         foldr'
           (\m0 m1 -> [|$(m0) <> $(m1)|])
           [|code ""|]
-          [ [|code $(litE $ stringL $ "const $" <> var <> " = ") <> toJSExpr $(varE $ mkName var) <> code "; "|]
+          [ [|code $(litE $ stringL $ "const $" <> var <> " = ") <> toJS $(varE $ mkName var) <> code "; "|]
             | var <- vars
           ]
   [|code "(async () => { " <> $(js_code_header) <> code $(litE $ stringL $ js_code <> " })()")|]

--- a/inline-js/src/Language/JavaScript/Inline/TH.hs
+++ b/inline-js/src/Language/JavaScript/Inline/TH.hs
@@ -11,8 +11,8 @@ import Language.JavaScript.Inline.Core
 import Language.JavaScript.Parser.Lexer
 
 -- | Generate a 'JSExpr' from an inline JavaScript expression. Use @$var@ to
--- refer to a Haskell variable @var@ (its type should be an 'ToJSExpr'
--- instance). Top-level @await@ is supported.
+-- refer to a Haskell variable @var@ (its type should be an 'ToJS' instance).
+-- Top-level @await@ is supported.
 expr :: QuasiQuoter
 expr =
   QuasiQuoter

--- a/inline-js/src/Language/JavaScript/Inline/TH.hs
+++ b/inline-js/src/Language/JavaScript/Inline/TH.hs
@@ -10,8 +10,8 @@ import Language.JavaScript.Inline.Class
 import Language.JavaScript.Inline.Core
 import Language.JavaScript.Parser.Lexer
 
--- | Generate a 'JSCode' from an inline JavaScript expression. Use @$var@ to
--- refer to a Haskell variable @var@ (its type should be an 'ToJSCode'
+-- | Generate a 'JSExpr' from an inline JavaScript expression. Use @$var@ to
+-- refer to a Haskell variable @var@ (its type should be an 'ToJSExpr'
 -- instance). Top-level @await@ is supported.
 expr :: QuasiQuoter
 expr =
@@ -22,7 +22,7 @@ expr =
       quoteDec = error "Language.JavaScript.Inline.TH: quoteDec"
     }
 
--- | Generate a 'JSCode' from an inline JavaScript code block. Use @return@ in
+-- | Generate a 'JSExpr' from an inline JavaScript code block. Use @return@ in
 -- the code block to return the result. Other rules of 'expr' also applies here.
 block :: QuasiQuoter
 block =
@@ -46,7 +46,7 @@ blockQuoter js_code = do
         foldr'
           (\m0 m1 -> [|$(m0) <> $(m1)|])
           [|code ""|]
-          [ [|code $(litE $ stringL $ "const $" <> var <> " = ") <> toJSCode $(varE $ mkName var) <> code "; "|]
+          [ [|code $(litE $ stringL $ "const $" <> var <> " = ") <> toJSExpr $(varE $ mkName var) <> code "; "|]
             | var <- vars
           ]
   [|code "(async () => { " <> $(js_code_header) <> code $(litE $ stringL $ js_code <> " })()")|]

--- a/inline-js/tests/inline-js-tests.hs
+++ b/inline-js/tests/inline-js-tests.hs
@@ -62,7 +62,7 @@ main =
 
 newtype I = I Int
   deriving (Eq, Show)
-  deriving (ToJSCode, FromEvalResult) via (Aeson Int)
+  deriving (ToJSExpr, FromEvalResult) via (Aeson Int)
 
 withSession :: Config -> (Session -> Assertion) -> Assertion
 withSession conf = bracket (newSession conf) closeSession

--- a/inline-js/tests/inline-js-tests.hs
+++ b/inline-js/tests/inline-js-tests.hs
@@ -62,7 +62,7 @@ main =
 
 newtype I = I Int
   deriving (Eq, Show)
-  deriving (ToJSExpr, FromEvalResult) via (Aeson Int)
+  deriving (ToJS, FromEvalResult) via (Aeson Int)
 
 withSession :: Config -> (Session -> Assertion) -> Assertion
 withSession conf = bracket (newSession conf) closeSession

--- a/inline-js/tests/inline-js-tests.hs
+++ b/inline-js/tests/inline-js-tests.hs
@@ -62,7 +62,7 @@ main =
 
 newtype I = I Int
   deriving (Eq, Show)
-  deriving (ToJS, FromEvalResult) via (Aeson Int)
+  deriving (ToJS, FromJS) via (Aeson Int)
 
 withSession :: Config -> (Session -> Assertion) -> Assertion
 withSession conf = bracket (newSession conf) closeSession

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2020-06-29
+resolver: nightly-2020-07-04
 packages:
   - inline-js
   - inline-js-core


### PR DESCRIPTION
Massive renamings in public API. The docs are adjusted accordingly.

* `JSCode` is renamed to `JSExpr` for more clarity: it must be a valid JavaScript expression
* `ToJSCode`/`FromEvalResult` are renamed to `ToJS/FromJS`, not because we want to save a few keystrokes, but because they'll also be responsible for data marshaling when exporting Haskell functions to JavaScript, so we should use generalized names starting from now.
* We now use `evalJSON` in `inline-js-core` for the `FromJS` instance of `Aeson a`. The relevant `EncodedJSON` wrapper type is also exported, in case people would like to work with a non-`aeson` JSON library.