### PR TITLE
Factor out `decodeAndEvalJSExpr`

### DIFF
--- a/inline-js-core/src/Language/JavaScript/Inline/Core/Message.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Core/Message.hs
@@ -23,7 +23,7 @@ data JSExprSegment
   | JSValLiteral JSVal
   deriving (Show)
 
--- | Represents a JavaScript expression. Top-level @await@ is supported.
+-- | Represents a JavaScript expression.
 --
 -- Use the 'IsString' instance to convert a 'String' to 'JSExpr', and the
 -- 'Semigroup' instance for concating 'JSExpr'. It's also possible to embed


### PR DESCRIPTION
The logic to decode a `JSExpr` from a message buffer and evaluate it has been factored out to the `decodeAndEvalJSExpr` method. Later we'll add other variants of messages which include `JSExpr` payload (e.g. `HSEvalResponse`), thus the refactoring. `decodeAndEvalJSExpr` support specifying whether the `JSExpr` should be evaluated in async/sync mode.