### PR TITLE
Move ToJS/FromJS type classes to inline-js-core

### DIFF
--- a/inline-js-core/inline-js-core.cabal
+++ b/inline-js-core/inline-js-core.cabal
@@ -4,7 +4,7 @@ cabal-version: 2.2
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: f780a27d5164b3a6f0bb56afa636d57bf8f67709d10087dcc18c1ba48ecbab95
+-- hash: c43c00d1e0184e6f21cddddb88e2abb3cb2b1c537850a8acb8676534896e2912
 
 name:           inline-js-core
 version:        0.0.1.0
@@ -32,6 +32,7 @@ library
   exposed-modules:
       Language.JavaScript.Inline.Core
   other-modules:
+      Language.JavaScript.Inline.Core.Class
       Language.JavaScript.Inline.Core.Exception
       Language.JavaScript.Inline.Core.Instruction
       Language.JavaScript.Inline.Core.IPC

--- a/inline-js-core/src/Language/JavaScript/Inline/Core.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Core.hs
@@ -13,6 +13,7 @@ module Language.JavaScript.Inline.Core
     -- * Haskell/JavaScript data marshaling
     JSExpr,
     JSVal,
+    EncodedString (..),
     EncodedJSON (..),
     ToJS (..),
     FromJS (..),
@@ -34,16 +35,11 @@ import Data.Proxy
 import Language.JavaScript.Inline.Core.Class
 import Language.JavaScript.Inline.Core.Exception
 import Language.JavaScript.Inline.Core.JSVal
-import Language.JavaScript.Inline.Core.Message hiding
-  ( code,
-  )
+import Language.JavaScript.Inline.Core.Message
 import Language.JavaScript.Inline.Core.Session
+import Language.JavaScript.Inline.Core.Utils
 import System.Directory
 import System.IO.Unsafe
-
--- | Embed a 'String' as a @string@ expression.
-string :: String -> JSExpr
-string = JSExpr . pure . StringLiteral
 
 -- | Evaluate a 'JSExpr' and return the result. Evaluation is /asynchronous/.
 -- When this function returns, the eval request has been sent to the eval
@@ -95,3 +91,6 @@ importMJS s p = do
     "import('url').then(url => import(url.pathToFileURL("
       <> string p'
       <> ")))"
+
+string :: String -> JSExpr
+string = toJS . EncodedString . stringToLBS

--- a/inline-js-core/src/Language/JavaScript/Inline/Core.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Core.hs
@@ -8,21 +8,16 @@ module Language.JavaScript.Inline.Core
     newSession,
     closeSession,
 
-    -- * Evaluation requests
+    -- * Haskell/JavaScript data marshaling
     JSExpr,
     JSVal,
-    code,
-    buffer,
-    string,
-    json,
-    jsval,
+    EncodedJSON (..),
+    ToJS (..),
+    FromJS (..),
 
     -- * Performing evaluation
     -- $notes-eval
-    evalNone,
-    evalBuffer,
-    evalJSON,
-    evalJSVal,
+    eval,
     importCJS,
     importMJS,
 
@@ -33,10 +28,8 @@ module Language.JavaScript.Inline.Core
   )
 where
 
-import qualified Data.ByteString.Lazy as LBS
-import Data.String
+import Language.JavaScript.Inline.Core.Class
 import Language.JavaScript.Inline.Core.Exception
-import Language.JavaScript.Inline.Core.Instruction
 import Language.JavaScript.Inline.Core.JSVal
 import Language.JavaScript.Inline.Core.Message hiding
   ( code,
@@ -44,27 +37,9 @@ import Language.JavaScript.Inline.Core.Message hiding
 import Language.JavaScript.Inline.Core.Session
 import System.Directory
 
--- | Convert a 'String' to 'JSExpr'. In most cases, using the 'IsString'
--- instance with the @OverloadedStrings@ extension is more convenient.
-code :: String -> JSExpr
-code = fromString
-
--- | Embed a 'LBS.ByteString' as a @Buffer@ expression.
-buffer :: LBS.ByteString -> JSExpr
-buffer = JSExpr . pure . BufferLiteral
-
 -- | Embed a 'String' as a @string@ expression.
 string :: String -> JSExpr
 string = JSExpr . pure . StringLiteral
-
--- | Embed a UTF-8 encoded JSON expression. It will be parsed with
--- @JSON.parse()@.
-json :: LBS.ByteString -> JSExpr
-json = JSExpr . pure . JSONLiteral
-
--- | Embed a 'JSVal' as an expression.
-jsval :: JSVal -> JSExpr
-jsval = JSExpr . pure . JSValLiteral
 
 -- $notes-eval
 --
@@ -96,7 +71,7 @@ jsval = JSExpr . pure . JSValLiteral
 importCJS :: Session -> FilePath -> IO JSVal
 importCJS s p = do
   p' <- makeAbsolute p
-  evalJSVal s $ "require(" <> string p' <> ")"
+  eval s $ "require(" <> string p' <> ")"
 
 -- | Import an ECMAScript module file and return its module namespace object.
 -- The module file path can be absolute, or relative to the current Haskell
@@ -104,7 +79,7 @@ importCJS s p = do
 importMJS :: Session -> FilePath -> IO JSVal
 importMJS s p = do
   p' <- makeAbsolute p
-  evalJSVal s $
+  eval s $
     "import('url').then(url => import(url.pathToFileURL("
       <> string p'
       <> ")))"

--- a/inline-js-core/src/Language/JavaScript/Inline/Core/Class.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Core/Class.hs
@@ -12,6 +12,12 @@ import Language.JavaScript.Inline.Core.JSVal
 import Language.JavaScript.Inline.Core.Message
 import Language.JavaScript.Inline.Core.Session
 
+-- | UTF-8 encoded string.
+newtype EncodedString = EncodedString
+  { unEncodedString :: LBS.ByteString
+  }
+  deriving (Show)
+
 -- | UTF-8 encoded JSON.
 newtype EncodedJSON = EncodedJSON
   { unEncodedJSON :: LBS.ByteString
@@ -24,6 +30,9 @@ class ToJS a where
 
 instance ToJS LBS.ByteString where
   toJS = JSExpr . pure . BufferLiteral
+
+instance ToJS EncodedString where
+  toJS = JSExpr . pure . StringLiteral . unEncodedString
 
 instance ToJS EncodedJSON where
   toJS = JSExpr . pure . BufferLiteral . unEncodedJSON
@@ -39,6 +48,9 @@ instance RawFromJS () where
 
 instance RawFromJS LBS.ByteString where
   rawEval = evalBuffer
+
+instance RawFromJS EncodedString where
+  rawEval = coerce evalBuffer
 
 instance RawFromJS EncodedJSON where
   rawEval = coerce evalJSON
@@ -75,6 +87,11 @@ instance FromJS () where
 
 instance FromJS LBS.ByteString where
   type RawJSType LBS.ByteString = LBS.ByteString
+  toRawJSType _ = "a => a"
+  fromRawJSType = pure
+
+instance FromJS EncodedString where
+  type RawJSType EncodedString = EncodedString
   toRawJSType _ = "a => a"
   fromRawJSType = pure
 

--- a/inline-js-core/src/Language/JavaScript/Inline/Core/Class.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Core/Class.hs
@@ -1,12 +1,9 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 
 module Language.JavaScript.Inline.Core.Class where
 
-import Control.Exception
 import qualified Data.ByteString.Lazy as LBS
 import Data.Coerce
 import Data.Proxy
@@ -14,7 +11,6 @@ import Language.JavaScript.Inline.Core.Instruction
 import Language.JavaScript.Inline.Core.JSVal
 import Language.JavaScript.Inline.Core.Message
 import Language.JavaScript.Inline.Core.Session
-import System.IO.Unsafe
 
 -- | To embed a Haskell value into a 'JSExpr', its type should be an instance of
 -- 'ToJS'.
@@ -92,15 +88,3 @@ instance FromJS JSVal where
   type RawJSType JSVal = JSVal
   toRawJSType _ = "a => a"
   fromRawJSType = pure
-
--- | The polymorphic eval function.
-eval :: forall a. FromJS a => Session -> JSExpr -> IO a
-eval s c = do
-  r <-
-    rawEval s $
-      "Promise.resolve("
-        <> c
-        <> ").then("
-        <> toRawJSType (Proxy @a)
-        <> ")"
-  unsafeInterleaveIO $ fromRawJSType =<< evaluate r

--- a/inline-js-core/src/Language/JavaScript/Inline/Core/Message.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Core/Message.hs
@@ -27,8 +27,7 @@ data JSExprSegment
 --
 -- Use the 'IsString' instance to convert a 'String' to 'JSExpr', and the
 -- 'Semigroup' instance for concating 'JSExpr'. It's also possible to embed
--- other things into 'JSExpr', e.g. a buffer/string literal, JSON value or a
--- 'JSVal'.
+-- other things into 'JSExpr', e.g. a buffer literal, JSON value or a 'JSVal'.
 newtype JSExpr = JSExpr
   { unJSExpr :: NE.NonEmpty JSExprSegment
   }

--- a/inline-js-core/src/Language/JavaScript/Inline/Core/Message.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Core/Message.hs
@@ -16,9 +16,9 @@ import Language.JavaScript.Inline.Core.JSVal
 import Language.JavaScript.Inline.Core.Utils
 
 data JSExprSegment
-  = Code String
+  = Code LBS.ByteString
   | BufferLiteral LBS.ByteString
-  | StringLiteral String
+  | StringLiteral LBS.ByteString
   | JSONLiteral LBS.ByteString
   | JSValLiteral JSVal
   deriving (Show)
@@ -34,7 +34,7 @@ newtype JSExpr = JSExpr
   deriving (Semigroup, Show)
 
 instance IsString JSExpr where
-  fromString = JSExpr . pure . Code
+  fromString = JSExpr . pure . Code . stringToLBS
 
 data JSReturnType
   = ReturnNone
@@ -70,9 +70,9 @@ messageHSPut msg = case msg of
       <> foldMap' exprSegmentPut (unJSExpr code)
       <> returnTypePut returnType
     where
-      exprSegmentPut (Code s) = word8Put 0 <> lbsPut (stringToLBS s)
+      exprSegmentPut (Code s) = word8Put 0 <> lbsPut s
       exprSegmentPut (BufferLiteral s) = word8Put 1 <> lbsPut s
-      exprSegmentPut (StringLiteral s) = word8Put 2 <> lbsPut (stringToLBS s)
+      exprSegmentPut (StringLiteral s) = word8Put 2 <> lbsPut s
       exprSegmentPut (JSONLiteral s) = word8Put 3 <> lbsPut s
       exprSegmentPut (JSValLiteral v) =
         word8Put 4 <> word64Put (unsafeUseJSVal v)

--- a/inline-js/inline-js.cabal
+++ b/inline-js/inline-js.cabal
@@ -4,7 +4,7 @@ cabal-version: 2.2
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 800c01edd36cdc73adf826587aa5fde5cb4b472126810bcd86a9ebd263b06d2d
+-- hash: bacaf170dbb20d108ceaf6415a60868ffe8191e644bab0c3d88211a5d1b09fbb
 
 name:           inline-js
 version:        0.0.1.0
@@ -31,7 +31,7 @@ library
   exposed-modules:
       Language.JavaScript.Inline
   other-modules:
-      Language.JavaScript.Inline.Class
+      Language.JavaScript.Inline.Aeson
       Language.JavaScript.Inline.TH
       Paths_inline_js
   autogen-modules:

--- a/inline-js/src/Language/JavaScript/Inline.hs
+++ b/inline-js/src/Language/JavaScript/Inline.hs
@@ -2,14 +2,8 @@ module Language.JavaScript.Inline
   ( -- * Core functionalities
     module Language.JavaScript.Inline.Core,
 
-    -- * Haskell/JavaScript data marshaling type classes
-    ToJS (..),
-    FromJS (..),
+    -- * @aeson@ support
     Aeson (..),
-    EncodedJSON (..),
-
-    -- * Polymorphic eval function
-    eval,
 
     -- * QuasiQuoters for inline JavaScript
     expr,
@@ -17,6 +11,6 @@ module Language.JavaScript.Inline
   )
 where
 
-import Language.JavaScript.Inline.Class
+import Language.JavaScript.Inline.Aeson
 import Language.JavaScript.Inline.Core
 import Language.JavaScript.Inline.TH

--- a/inline-js/src/Language/JavaScript/Inline/Aeson.hs
+++ b/inline-js/src/Language/JavaScript/Inline/Aeson.hs
@@ -1,0 +1,27 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Language.JavaScript.Inline.Aeson where
+
+import qualified Data.Aeson as A
+import Language.JavaScript.Inline.Core
+
+-- | If a Haskell type @a@ has 'A.ToJSON' and 'A.FromJSON' instances, then we
+-- can derive 'ToJS' and 'FromJS' instances for it using:
+--
+-- 1. @deriving (ToJS, FromJS) via (Aeson a)@, using the @DerivingVia@ extension
+-- 2. @deriving (ToJS, FromJS)@, using the @GeneralizedNewtypeDeriving@
+--    extension
+newtype Aeson a = Aeson
+  { unAeson :: a
+  }
+
+instance A.ToJSON a => ToJS (Aeson a) where
+  toJS = toJS . EncodedJSON . A.encode . unAeson
+
+instance A.FromJSON a => FromJS (Aeson a) where
+  type RawJSType (Aeson a) = EncodedJSON
+  toRawJSType _ = "a => a"
+  fromRawJSType s = case A.eitherDecode' (unEncodedJSON s) of
+    Left err -> fail err
+    Right a -> pure $ Aeson a

--- a/inline-js/src/Language/JavaScript/Inline/Aeson.hs
+++ b/inline-js/src/Language/JavaScript/Inline/Aeson.hs
@@ -15,6 +15,7 @@ import Language.JavaScript.Inline.Core
 newtype Aeson a = Aeson
   { unAeson :: a
   }
+  deriving (Show)
 
 instance A.ToJSON a => ToJS (Aeson a) where
   toJS = toJS . EncodedJSON . A.encode . unAeson

--- a/inline-js/src/Language/JavaScript/Inline/Class.hs
+++ b/inline-js/src/Language/JavaScript/Inline/Class.hs
@@ -99,7 +99,7 @@ instance FromJS EncodedJSON where
 instance A.FromJSON a => FromJS (Aeson a) where
   type RawJSType (Aeson a) = EncodedJSON
   toRawJSType _ = "a => a"
-  fromRawJSType s = case A.eitherDecode' (coerce s) of
+  fromRawJSType s = case A.eitherDecode' (unEncodedJSON s) of
     Left err -> fail err
     Right a -> pure $ Aeson a
 

--- a/inline-js/src/Language/JavaScript/Inline/Class.hs
+++ b/inline-js/src/Language/JavaScript/Inline/Class.hs
@@ -32,8 +32,11 @@ class ToJS a where
 instance ToJS LBS.ByteString where
   toJS = buffer
 
+instance ToJS EncodedJSON where
+  toJS = json . unEncodedJSON
+
 instance A.ToJSON a => ToJS (Aeson a) where
-  toJS = json . A.encode . unAeson
+  toJS = toJS . EncodedJSON . A.encode . unAeson
 
 instance ToJS JSVal where
   toJS = jsval

--- a/inline-js/src/Language/JavaScript/Inline/TH.hs
+++ b/inline-js/src/Language/JavaScript/Inline/TH.hs
@@ -4,9 +4,9 @@ module Language.JavaScript.Inline.TH where
 
 import Data.Foldable
 import Data.List
+import Data.String
 import Language.Haskell.TH
 import Language.Haskell.TH.Quote
-import Language.JavaScript.Inline.Class
 import Language.JavaScript.Inline.Core
 import Language.JavaScript.Parser.Lexer
 
@@ -45,8 +45,8 @@ blockQuoter js_code = do
       js_code_header =
         foldr'
           (\m0 m1 -> [|$(m0) <> $(m1)|])
-          [|code ""|]
-          [ [|code $(litE $ stringL $ "const $" <> var <> " = ") <> toJS $(varE $ mkName var) <> code "; "|]
+          [|fromString ""|]
+          [ [|fromString $(litE $ stringL $ "const $" <> var <> " = ") <> toJS $(varE $ mkName var) <> fromString "; "|]
             | var <- vars
           ]
-  [|code "(async () => { " <> $(js_code_header) <> code $(litE $ stringL $ js_code <> " })()")|]
+  [|fromString "(async () => { " <> $(js_code_header) <> fromString $(litE $ stringL $ js_code <> " })()")|]


### PR DESCRIPTION
One step further on implementing Haskell function exports.

* The `ToJS`/`FromJS` type classes are now moved to `inline-js-core`. `inline-js` adds `aeson` marshaling support on top of that.
* `inline-js-core` only exports the polymorphic `eval` function.
* Besides `EncodedJSON`, there's a new `EncodedString` newtype wrapper for marshaling strings, since it's a really common use case.