### PR TITLE
Simplify sdist/haddock job scripts

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -229,14 +229,8 @@ jobs:
       - name: upload-artifact
         uses: actions/upload-artifact@v2
         with:
-          name: inline-js-0.0.1.0.tar.gz
-          path: dist-newstyle/sdist/inline-js-0.0.1.0.tar.gz
-
-      - name: upload-artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: inline-js-core-0.0.1.0.tar.gz
-          path: dist-newstyle/sdist/inline-js-core-0.0.1.0.tar.gz
+          name: sdist
+          path: dist-newstyle/sdist/*.tar.gz
 
   haddock:
     name: haddock
@@ -264,14 +258,8 @@ jobs:
       - name: upload-artifact
         uses: actions/upload-artifact@v2
         with:
-          name: inline-js-0.0.1.0-docs.tar.gz
-          path: dist-newstyle/inline-js-0.0.1.0-docs.tar.gz
-
-      - name: upload-artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: inline-js-core-0.0.1.0-docs.tar.gz
-          path: dist-newstyle/inline-js-core-0.0.1.0-docs.tar.gz
+          name: haddock
+          path: dist-newstyle/*-docs.tar.gz
 
   docs:
     name: docs

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2020-07-04
+resolver: nightly-2020-07-12
 packages:
   - inline-js
   - inline-js-core


### PR DESCRIPTION
Use a single `upload-artifact` step for uploading sdist/haddock tarballs.