### PR TITLE
Fix EncodedJSON ToJS instance

### DIFF
--- a/inline-js-core/src/Language/JavaScript/Inline/Core/Class.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Core/Class.hs
@@ -37,7 +37,7 @@ instance ToJS EncodedString where
   toJS = JSExpr . pure . StringLiteral . unEncodedString
 
 instance ToJS EncodedJSON where
-  toJS = JSExpr . pure . BufferLiteral . unEncodedJSON
+  toJS = JSExpr . pure . JSONLiteral . unEncodedJSON
 
 instance ToJS JSVal where
   toJS = JSExpr . pure . JSValLiteral


### PR DESCRIPTION
Otherwise we'd get something like `{"type": "Buffer", "data": [...]}` at runtime instead, as a result of calling `JSON.stringify()` on a `Buffer` directly.