### PR TITLE
Implement Haskell function exporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# `inline-js`: Call JavaScript from Haskell
+# `inline-js`: Call JavaScript from Haskell, and vice versa!
 
 [![GitHub Actions](https://github.com/tweag/inline-js/workflows/pipeline/badge.svg?branch=master)](https://github.com/tweag/inline-js/actions?query=branch%3Amaster)
 [![Gitter](https://img.shields.io/gitter/room/tweag/inline-js)](https://gitter.im/tweag/inline-js)
@@ -8,6 +8,7 @@
 - Manage `node` sessions which run the eval server script for Haskell/JavaScript
   interop
 - Evaluate expressions with `require()`/`import()` and top-level `await` support
+- Export Haskell functions to async JavaScript functions
 - Load third party libraries in user-specified `node_modules`
 - Garbage-collected `JSVal` references in Haskell
 - Support `Promise`-based async evaluation
@@ -18,7 +19,7 @@
 
 ## Planned features
 
-- Export Haskell functions as async/sync JavaScript functions
+- Export Haskell functions to _synchronous_ JavaScript functions
 - Integrate with TypeScript compiler, generate Haskell code from TypeScript
   `.d.ts` code
 - Integrate with headless browser testing frameworks like

--- a/inline-js-core/inline-js-core.cabal
+++ b/inline-js-core/inline-js-core.cabal
@@ -4,7 +4,7 @@ cabal-version: 2.2
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: c43c00d1e0184e6f21cddddb88e2abb3cb2b1c537850a8acb8676534896e2912
+-- hash: 6a5e44f2a432fa2cd38f55764e92c7e3a7b29d531688daa96c8b24fb87975cf5
 
 name:           inline-js-core
 version:        0.0.1.0
@@ -34,6 +34,7 @@ library
   other-modules:
       Language.JavaScript.Inline.Core.Class
       Language.JavaScript.Inline.Core.Exception
+      Language.JavaScript.Inline.Core.Export
       Language.JavaScript.Inline.Core.Instruction
       Language.JavaScript.Inline.Core.IPC
       Language.JavaScript.Inline.Core.JSVal

--- a/inline-js-core/src/Language/JavaScript/Inline/Core.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Core.hs
@@ -24,6 +24,9 @@ module Language.JavaScript.Inline.Core
     importCJS,
     importMJS,
 
+    -- * Exporting Haskell functions to JavaScript
+    export,
+
     -- * Exceptions
     NodeVersionUnsupported (..),
     EvalError (..),

--- a/inline-js-core/src/Language/JavaScript/Inline/Core/Export.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Core/Export.hs
@@ -1,0 +1,27 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Language.JavaScript.Inline.Core.Export where
+
+import qualified Data.ByteString.Lazy as LBS
+import Data.Proxy
+import Language.JavaScript.Inline.Core.Class
+import Language.JavaScript.Inline.Core.Message
+import Language.JavaScript.Inline.Core.Session
+
+class Export f where
+  argsToRawJSType :: Proxy f -> [(JSExpr, RawJSType)]
+  monomorphize :: Session -> f -> [LBS.ByteString] -> IO JSExpr
+
+instance ToJS r => Export (IO r) where
+  argsToRawJSType _ = []
+  monomorphize _ m [] = toJS <$> m
+  monomorphize _ _ _ = fail "Language.JavaScript.Inline.Core.Export: impossible"
+
+instance (FromJS a, Export b) => Export (a -> b) where
+  argsToRawJSType _ =
+    (toRawJSType (Proxy @a), rawJSType (Proxy @a)) : argsToRawJSType (Proxy @b)
+  monomorphize s f (x : xs) = do
+    a <- fromJS s x
+    monomorphize s (f a) xs
+  monomorphize _ _ _ = fail "Language.JavaScript.Inline.Core.Export: impossible"

--- a/inline-js-core/src/Language/JavaScript/Inline/Core/Instruction.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Core/Instruction.hs
@@ -1,15 +1,21 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Language.JavaScript.Inline.Core.Instruction where
 
 import Control.Concurrent
 import Control.Exception
+import Data.Binary.Get
 import qualified Data.ByteString.Lazy as LBS
 import Data.IORef
 import qualified Data.IntSet as IS
+import Data.Proxy
 import Foreign
 import Language.JavaScript.Inline.Core.Exception
+import Language.JavaScript.Inline.Core.Export
+import Language.JavaScript.Inline.Core.JSVal
 import Language.JavaScript.Inline.Core.Message
 import Language.JavaScript.Inline.Core.Session
 import Language.JavaScript.Inline.Core.Utils
@@ -39,13 +45,64 @@ evalWithDecoder _return_type _decoder _session@Session {..} _code = do
   sessionSend
     _session
     JSEvalRequest
-      { evalRequestId = _id,
+      { jsEvalRequestId = _id,
         code = _code,
         returnType = _return_type
       }
   touch _code
   atomicModifyIORef' pendingCallbacks $
     \_cbs -> (IS.insert (intFromStablePtr _sp) _cbs, ())
+  unsafeInterleaveIO $
+    takeMVar _inbox >>= \case
+      Left (SomeException _err) -> throwIO _err
+      Right _result -> pure _result
+
+-- | Export a Haskell function as a JavaScript async function.
+--
+-- The Haskell function type should be @a -> b -> .. -> IO r@, where the
+-- arguments @a@, @b@, etc are 'Language.JavaScript.Inline.Core.Class.FromJS'
+-- instances, and the result @r@ is 'Language.JavaScript.Inline.Core.Class.ToJS'
+-- instance.
+--
+-- The resulting JavaScript async function can be called like normal functions,
+-- set up as callback, etc. When called, the exported Haskell function is run in
+-- a forked thread. If the Haskell function throws, the JavaScript function will
+-- reject with an @Error@ containing the Haskell exception string.
+--
+-- Unlike ordinary 'JSVal's returned by 'Language.JavaScript.Inline.Core.eval',
+-- the 'JSVal' of exported function is not garbage collected.
+export :: forall f. Export f => Session -> f -> IO JSVal
+export _session@Session {..} f = do
+  _inbox <- newEmptyMVar
+  let args_type = argsToRawJSType (Proxy @f)
+      f' = monomorphize _session f
+      _decoder _jsval_id_buf = do
+        _jsval_id <- runGetExact getWord64host _jsval_id_buf
+        newJSVal _jsval_id (pure ())
+      _cb _resp = case _resp of
+        Left _err_buf ->
+          putMVar _inbox $
+            Left $
+              toException
+                EvalError
+                  { evalErrorMessage = stringFromLBS _err_buf
+                  }
+        Right _result_buf -> do
+          _result <- _decoder _result_buf
+          putMVar _inbox $ Right _result
+  _sp_cb <- newStablePtr _cb
+  _sp_f <- newStablePtr f'
+  let _id_cb = word64FromStablePtr _sp_cb
+      _id_f = word64FromStablePtr _sp_f
+  sessionSend
+    _session
+    HSExportRequest
+      { exportRequestId = _id_cb,
+        exportFuncId = _id_f,
+        argsType = args_type
+      }
+  atomicModifyIORef' pendingCallbacks $
+    \_cbs -> (IS.insert (intFromStablePtr _sp_cb) _cbs, ())
   unsafeInterleaveIO $
     takeMVar _inbox >>= \case
       Left (SomeException _err) -> throwIO _err

--- a/inline-js-core/src/Language/JavaScript/Inline/Core/Session.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Core/Session.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE RecursiveDo #-}
 {-# LANGUAGE StrictData #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TupleSections #-}
@@ -7,6 +8,7 @@
 
 module Language.JavaScript.Inline.Core.Session where
 
+import Control.Concurrent
 import Control.Exception
 import qualified Data.ByteString as BS
 import Data.ByteString.Builder
@@ -16,6 +18,7 @@ import qualified Data.IntSet as IS
 import Data.Maybe
 import Distribution.Simple.Utils
 import Foreign
+import GHC.IO (catchAny)
 import Language.JavaScript.Inline.Core.Exception
 import Language.JavaScript.Inline.Core.IPC
 import Language.JavaScript.Inline.Core.Message
@@ -105,52 +108,79 @@ newSession Config {..} = do
           std_out = CreatePipe
         }
   _cbs_ref <- newIORef IS.empty
-  let on_recv msg_buf = do
-        msg <- runGetExact messageJSGet msg_buf
-        case msg of
-          JSEvalResponse {..} -> do
-            let sp = word64ToStablePtr responseId
-            atomicModifyIORef' _cbs_ref $
-              \_cbs -> (IS.delete (intFromStablePtr sp) _cbs, ())
-            cb <- deRefStablePtr sp
-            freeStablePtr sp
-            cb responseContent
-          -- todo: should make all subsequent operations invalid immediately
-          -- here, possibly via a session state atomic variable. also cleanup
-          -- tmp dir.
-          FatalError err_buf -> do
-            _cbs <- atomicModifyIORef _cbs_ref (throw SessionClosed,)
-            for_ (IS.toList _cbs) $ \_cb_id -> do
-              let sp = intToStablePtr _cb_id
+  mdo
+    let on_recv msg_buf = do
+          msg <- runGetExact messageJSGet msg_buf
+          case msg of
+            JSEvalResponse {..} -> do
+              let sp = word64ToStablePtr jsEvalResponseId
+              atomicModifyIORef' _cbs_ref $
+                \_cbs -> (IS.delete (intFromStablePtr sp) _cbs, ())
               cb <- deRefStablePtr sp
               freeStablePtr sp
-              cb $ Left err_buf
-      ipc_post_close = do
-        _ <- waitForProcess _ph
-        pure ()
-  _ipc <-
-    ipcFork $
-      ipcFromHandles
-        _wh
-        _rh
-        IPC
-          { send = error "newSession: send",
-            recv = error "newSession: recv",
-            onRecv = on_recv,
-            closeMsg = toLazyByteString $ messageHSPut Close,
-            preClose = error "newSession: preClose",
-            postClose = ipc_post_close
-          }
-  let session_close = do
-        send _ipc $ closeMsg _ipc
-        ipc_post_close
-        removeDirectoryRecursive _root
-  pure
-    Session
-      { ipc = _ipc,
-        pendingCallbacks = _cbs_ref,
-        closeSession = session_close
-      }
+              cb jsEvalResponseContent
+            HSEvalRequest {..} -> do
+              _ <-
+                forkIO $
+                  catchAny
+                    ( do
+                        let sp = word64ToStablePtr hsEvalRequestFunc
+                        f <- deRefStablePtr sp
+                        r <- f args
+                        sessionSend
+                          _session
+                          HSEvalResponse
+                            { hsEvalResponseId = hsEvalRequestId,
+                              hsEvalResponseContent = Right r
+                            }
+                    )
+                    ( \err -> do
+                        let err_buf = stringToLBS $ show err
+                        sessionSend
+                          _session
+                          HSEvalResponse
+                            { hsEvalResponseId = hsEvalRequestId,
+                              hsEvalResponseContent = Left err_buf
+                            }
+                    )
+              pure ()
+            -- todo: should make all subsequent operations invalid immediately
+            -- here, possibly via a session state atomic variable. also cleanup
+            -- tmp dir.
+            FatalError err_buf -> do
+              _cbs <- atomicModifyIORef _cbs_ref (throw SessionClosed,)
+              for_ (IS.toList _cbs) $ \_cb_id -> do
+                let sp = intToStablePtr _cb_id
+                cb <- deRefStablePtr sp
+                freeStablePtr sp
+                cb $ Left err_buf
+        ipc_post_close = do
+          _ <- waitForProcess _ph
+          pure ()
+    _ipc <-
+      ipcFork $
+        ipcFromHandles
+          _wh
+          _rh
+          IPC
+            { send = error "newSession: send",
+              recv = error "newSession: recv",
+              onRecv = on_recv,
+              closeMsg = toLazyByteString $ messageHSPut Close,
+              preClose = error "newSession: preClose",
+              postClose = ipc_post_close
+            }
+    let session_close = do
+          send _ipc $ closeMsg _ipc
+          ipc_post_close
+          removeDirectoryRecursive _root
+        _session =
+          Session
+            { ipc = _ipc,
+              pendingCallbacks = _cbs_ref,
+              closeSession = session_close
+            }
+    pure _session
 
 sessionSend :: Session -> MessageHS -> IO ()
 sessionSend Session {..} msg = send ipc $ toLazyByteString $ messageHSPut msg


### PR DESCRIPTION
Left to future PRs:

* Support sync mode of exporting, so that you can use `inline-js` as a wasm runtime.
* Proper resource management of exported functions. Currently, they're never freed. And we can't use weak pointers in `node`. So for exported functions, we may want to introduce explicit `freeJSVal`.