### PR TITLE
Implement sync mode of Haskell function exporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 - Manage `node` sessions which run the eval server script for Haskell/JavaScript
   interop
 - Evaluate expressions with `require()`/`import()` and top-level `await` support
-- Export Haskell functions to async JavaScript functions
+- Export Haskell functions to async/sync JavaScript functions
 - Load third party libraries in user-specified `node_modules`
 - Garbage-collected `JSVal` references in Haskell
 - Support `Promise`-based async evaluation
@@ -19,7 +19,6 @@
 
 ## Planned features
 
-- Export Haskell functions to _synchronous_ JavaScript functions
 - Integrate with TypeScript compiler, generate Haskell code from TypeScript
   `.d.ts` code
 - Integrate with headless browser testing frameworks like

--- a/inline-js-core/src/Language/JavaScript/Inline/Core/Export.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Core/Export.hs
@@ -9,6 +9,10 @@ import Language.JavaScript.Inline.Core.Class
 import Language.JavaScript.Inline.Core.Message
 import Language.JavaScript.Inline.Core.Session
 
+-- | The class of Haskell functions which can be exported as JavaScript
+-- functions. The Haskell function type should be @a -> b -> .. -> IO r@, where
+-- the arguments @a@, @b@, etc are 'FromJS' instances, and the result @r@ is
+-- 'ToJS' instance.
 class Export f where
   argsToRawJSType :: Proxy f -> [(JSExpr, RawJSType)]
   monomorphize :: Session -> f -> [LBS.ByteString] -> IO JSExpr

--- a/inline-js/tests/inline-js-tests.hs
+++ b/inline-js/tests/inline-js-tests.hs
@@ -70,6 +70,15 @@ main =
             let x = V $ A.String "asdf"
                 y = V $ A.String "233"
             r <- eval s [expr| $v($x, $y) |]
+            r @?= V (A.Array [A.String "asdf", A.String "233"]),
+        testCase "exportSync" $
+          withDefaultSession $ \s -> do
+            let f :: V -> V -> IO V
+                f (V x) (V y) = pure $ V $ A.Array [x, y]
+            v <- exportSync s f
+            let x = V $ A.String "asdf"
+                y = V $ A.String "233"
+            r <- eval s [expr| $v($x, $y) |]
             r @?= V (A.Array [A.String "asdf", A.String "233"])
       ]
 


### PR DESCRIPTION
Haskell functions can now be exported as JavaScript sync functions. The main desired use case is using `inline-js` as the infrastructure of running WebAssembly modules, since host Haskell functions can now be used as wasm imports.