### PR TITLE
Simplify handling of FatalError messages

### DIFF
--- a/inline-js-core/inline-js-core.cabal
+++ b/inline-js-core/inline-js-core.cabal
@@ -4,7 +4,7 @@ cabal-version: 2.2
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 6a5e44f2a432fa2cd38f55764e92c7e3a7b29d531688daa96c8b24fb87975cf5
+-- hash: 0714fa3300694befb9af9b42ff74b594ea2db1cfe552bab8f2c74e02f3a61ff8
 
 name:           inline-js-core
 version:        0.0.1.0
@@ -58,6 +58,7 @@ library
     , filepath
     , ghc-prim
     , process
+    , stm
     , template-haskell
     , text
   default-language: Haskell2010

--- a/inline-js-core/package.yaml
+++ b/inline-js-core/package.yaml
@@ -26,6 +26,7 @@ dependencies:
   - filepath
   - ghc-prim
   - process
+  - stm
   - template-haskell
   - text
 

--- a/inline-js-core/src/Language/JavaScript/Inline/Core/Instruction.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Core/Instruction.hs
@@ -1,11 +1,10 @@
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 
 module Language.JavaScript.Inline.Core.Instruction where
 
-import Control.Concurrent
+import Control.Concurrent.STM
 import Control.Exception
 import Data.Binary.Get
 import qualified Data.ByteString.Lazy as LBS
@@ -25,20 +24,9 @@ evalWithDecoder ::
   Session ->
   JSExpr ->
   IO a
-evalWithDecoder _return_type _decoder _session _code = do
-  _inbox <- newEmptyMVar
-  let _cb _resp = case _resp of
-        Left _err_buf ->
-          putMVar _inbox $
-            Left $
-              toException
-                EvalError
-                  { evalErrorMessage = stringFromLBS _err_buf
-                  }
-        Right _result_buf -> do
-          _result <- _decoder _session _result_buf
-          putMVar _inbox $ Right _result
-  _sp <- newStablePtr _cb
+evalWithDecoder _return_type _decoder _session@Session {..} _code = do
+  _inbox <- newEmptyTMVarIO
+  _sp <- newStablePtr _inbox
   let _id = word64FromStablePtr _sp
   sessionSend
     _session
@@ -48,43 +36,37 @@ evalWithDecoder _return_type _decoder _session _code = do
         returnType = _return_type
       }
   touch _code
-  unsafeInterleaveIO $
-    takeMVar _inbox >>= \case
-      Left (SomeException _err) -> throwIO _err
-      Right _result -> pure _result
+  unsafeInterleaveIO $ do
+    _resp <- atomically $ takeTMVar _inbox `orElse` readTMVar fatalErrorInbox
+    freeStablePtr _sp
+    case _resp of
+      Left _err_buf ->
+        throwIO $ EvalError {evalErrorMessage = stringFromLBS _err_buf}
+      Right _result_buf -> _decoder _session _result_buf
 
 exportAsyncOrSync :: forall f. Export f => Bool -> Session -> f -> IO JSVal
-exportAsyncOrSync _is_sync _session f = do
-  _inbox <- newEmptyMVar
+exportAsyncOrSync _is_sync _session@Session {..} f = do
+  _inbox <- newEmptyTMVarIO
   let args_type = argsToRawJSType (Proxy @f)
       f' = monomorphize _session f
-      _decoder _jsval_id_buf = do
-        _jsval_id <- runGetExact getWord64host _jsval_id_buf
-        newJSVal _jsval_id (pure ())
-      _cb _resp = case _resp of
-        Left _err_buf ->
-          putMVar _inbox $
-            Left $
-              toException
-                EvalError
-                  { evalErrorMessage = stringFromLBS _err_buf
-                  }
-        Right _result_buf -> do
-          _result <- _decoder _result_buf
-          putMVar _inbox $ Right _result
-  _sp_cb <- newStablePtr _cb
+  _sp_inbox <- newStablePtr _inbox
   _sp_f <- newStablePtr f'
-  let _id_cb = word64FromStablePtr _sp_cb
+  let _id_inbox = word64FromStablePtr _sp_inbox
       _id_f = word64FromStablePtr _sp_f
   sessionSend
     _session
     HSExportRequest
       { exportIsSync = _is_sync,
-        exportRequestId = _id_cb,
+        exportRequestId = _id_inbox,
         exportFuncId = _id_f,
         argsType = args_type
       }
-  unsafeInterleaveIO $
-    takeMVar _inbox >>= \case
-      Left (SomeException _err) -> throwIO _err
-      Right _result -> pure _result
+  unsafeInterleaveIO $ do
+    _resp <- atomically $ takeTMVar _inbox `orElse` readTMVar fatalErrorInbox
+    freeStablePtr _sp_inbox
+    case _resp of
+      Left _err_buf ->
+        throwIO $ EvalError {evalErrorMessage = stringFromLBS _err_buf}
+      Right _jsval_id_buf -> do
+        _jsval_id <- runGetExact getWord64host _jsval_id_buf
+        newJSVal _jsval_id (pure ())

--- a/inline-js-core/src/Language/JavaScript/Inline/Core/Session.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Core/Session.hs
@@ -9,17 +9,14 @@
 module Language.JavaScript.Inline.Core.Session where
 
 import Control.Concurrent
-import Control.Exception
+import Control.Concurrent.STM
 import qualified Data.ByteString as BS
 import Data.ByteString.Builder
-import Data.Foldable
-import Data.IORef
-import qualified Data.IntSet as IS
+import qualified Data.ByteString.Lazy as LBS
 import Data.Maybe
 import Distribution.Simple.Utils
 import Foreign
 import GHC.IO (catchAny)
-import Language.JavaScript.Inline.Core.Exception
 import Language.JavaScript.Inline.Core.IPC
 import Language.JavaScript.Inline.Core.Message
 import Language.JavaScript.Inline.Core.NodeVersion
@@ -78,6 +75,7 @@ defaultConfig =
 
 data Session = Session
   { ipc :: IPC,
+    fatalErrorInbox :: TMVar (Either LBS.ByteString LBS.ByteString),
     -- | After a 'Session' is closed, no more messages can be sent to @node@.
     -- @node@ may still run for some time to allow previous evaluation results
     -- to be sent back.
@@ -104,25 +102,25 @@ newSession Config {..} = do
             Just $
               kvDedup $
                 [("INLINE_JS_EXIT_ON_EVAL_ERROR", "1") | nodeExitOnEvalError]
-                  <> [("INLINE_JS_EXPORT_SYNC_BUFFER_SIZE", show nodeExportSyncBufferSize)]
+                  <> [ ( "INLINE_JS_EXPORT_SYNC_BUFFER_SIZE",
+                         show nodeExportSyncBufferSize
+                       )
+                     ]
                   <> map ("INLINE_JS_NODE_MODULES",) (maybeToList nodeModules)
                   <> nodeExtraEnv
                   <> _env,
           std_in = CreatePipe,
           std_out = CreatePipe
         }
-  _cbs_ref <- newIORef IS.empty
+  _inbox <- newEmptyTMVarIO
   mdo
     let on_recv msg_buf = do
           msg <- runGetExact messageJSGet msg_buf
           case msg of
             JSEvalResponse {..} -> do
-              let sp = word64ToStablePtr jsEvalResponseId
-              atomicModifyIORef' _cbs_ref $
-                \_cbs -> (IS.delete (intFromStablePtr sp) _cbs, ())
-              cb <- deRefStablePtr sp
-              freeStablePtr sp
-              cb jsEvalResponseContent
+              let _sp = word64ToStablePtr jsEvalResponseId
+              _inbox <- deRefStablePtr _sp
+              atomically $ putTMVar _inbox jsEvalResponseContent
             HSEvalRequest {..} -> do
               _ <-
                 forkIO $
@@ -153,13 +151,7 @@ newSession Config {..} = do
             -- todo: should make all subsequent operations invalid immediately
             -- here, possibly via a session state atomic variable. also cleanup
             -- tmp dir.
-            FatalError err_buf -> do
-              _cbs <- atomicModifyIORef _cbs_ref (throw SessionClosed,)
-              for_ (IS.toList _cbs) $ \_cb_id -> do
-                let sp = intToStablePtr _cb_id
-                cb <- deRefStablePtr sp
-                freeStablePtr sp
-                cb $ Left err_buf
+            FatalError err_buf -> atomically $ putTMVar _inbox $ Left err_buf
         ipc_post_close = do
           _ <- waitForProcess _ph
           pure ()
@@ -183,6 +175,7 @@ newSession Config {..} = do
         _session =
           Session
             { ipc = _ipc,
+              fatalErrorInbox = _inbox,
               closeSession = session_close
             }
     pure _session

--- a/inline-js-core/src/Language/JavaScript/Inline/Core/Session.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Core/Session.hs
@@ -78,7 +78,6 @@ defaultConfig =
 
 data Session = Session
   { ipc :: IPC,
-    pendingCallbacks :: IORef IS.IntSet,
     -- | After a 'Session' is closed, no more messages can be sent to @node@.
     -- @node@ may still run for some time to allow previous evaluation results
     -- to be sent back.
@@ -184,7 +183,6 @@ newSession Config {..} = do
         _session =
           Session
             { ipc = _ipc,
-              pendingCallbacks = _cbs_ref,
               closeSession = session_close
             }
     pure _session


### PR DESCRIPTION
When a `FatalError` message is received, all pending eval requests must be fulfilled with an exception. Previously, we had to keep a set of all pending requests so the `FatalError` message handler can traverse them. This seems to be an unnecessary complication.

This PR uses an STM-based approach instead: each eval request polls from two inboxes, one is the result inbox, the other is the fatal error inbox. The `FatalError` message handler only needs to fill the fatal error inbox, and all pending requests will automatically resolve with that error.

One minor problem compared to `MVar`-based inboxes: the thunks returned by the eval functions may not be safe to use inside other STM logic, due to the nested `atomically` restriction of STM. IMHO the benefit of simplified implementation outweighs this.