### PR TITLE
Misc improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![GitHub Actions](https://github.com/tweag/inline-js/workflows/pipeline/badge.svg?branch=master)](https://github.com/tweag/inline-js/actions?query=branch%3Amaster)
 [![Gitter](https://img.shields.io/gitter/room/tweag/inline-js)](https://gitter.im/tweag/inline-js)
+[![Netlify Status](https://api.netlify.com/api/v1/badges/b2320ec2-8feb-44d6-886a-8cd4728d92ad/deploy-status)](https://inline-js.netlify.app)
 
 ## Implemented features
 

--- a/inline-js-core/jsbits/index.js
+++ b/inline-js-core/jsbits/index.js
@@ -131,6 +131,7 @@ class WorkerContext {
     const expr_segs_len = Number(buf.readBigUInt64LE(p));
     p += 8;
     let expr = "";
+    let has_code = false;
     for (let i = 0; i < expr_segs_len; ++i) {
       const expr_seg_type = buf.readUInt8(p);
       p += 1;
@@ -141,6 +142,7 @@ class WorkerContext {
           p += 8;
           expr = `${expr}${this.decoder.end(buf.slice(p, p + expr_seg_len))}`;
           p += expr_seg_len;
+          has_code = has_code || Boolean(expr_seg_len);
           break;
         }
         case 1: {
@@ -188,15 +190,21 @@ class WorkerContext {
       }
     }
 
-    let expr_params = "require";
-    for (let i = 0; i < jsval_tmp.length; ++i) {
-      expr_params = `${expr_params}, __t${i.toString(36)}`;
+    let result;
+
+    if (!has_code && jsval_tmp.length === 1) {
+      result = jsval_tmp[0];
+    } else {
+      let expr_params = "require";
+      for (let i = 0; i < jsval_tmp.length; ++i) {
+        expr_params = `${expr_params}, __t${i.toString(36)}`;
+      }
+      expr = `${async ? "async " : ""}(${expr_params}) => (\n${expr}\n)`;
+      result = vm.runInThisContext(expr, {
+        lineOffset: -1,
+        importModuleDynamically: (spec) => import(spec),
+      })(require, ...jsval_tmp);
     }
-    expr = `${async ? "async " : ""}(${expr_params}) => (\n${expr}\n)`;
-    const result = vm.runInThisContext(expr, {
-      lineOffset: -1,
-      importModuleDynamically: (spec) => import(spec),
-    })(require, ...jsval_tmp);
 
     return { p: p, result: result };
   }

--- a/inline-js-core/jsbits/index.js
+++ b/inline-js-core/jsbits/index.js
@@ -6,7 +6,6 @@ const string_decoder = require("string_decoder");
 const util = require("util");
 const vm = require("vm");
 const worker_threads = require("worker_threads");
-const { SSL_OP_SSLEAY_080_CLIENT_DH_BUG } = require("constants");
 
 class JSValContext {
   constructor() {

--- a/inline-js-core/jsbits/index.js
+++ b/inline-js-core/jsbits/index.js
@@ -92,15 +92,14 @@ class MainContext {
   onWorkerMessage(buf_msg) {
     this.send(bufferFromArrayBufferView(buf_msg));
   }
-  async onUncaughtException(err) {
+  onUncaughtException(err) {
     const err_str = `${err.stack ? err.stack : err}`;
     const err_buf = Buffer.from(err_str, "utf-8");
     const resp_buf = Buffer.allocUnsafe(9 + err_buf.length);
     resp_buf.writeUInt8(2, 0);
     resp_buf.writeBigUInt64LE(BigInt(err_buf.length), 1);
     err_buf.copy(resp_buf, 9);
-    await this.send(resp_buf);
-    process.exit(1);
+    this.send(resp_buf).finally(() => process.exit(1));
   }
 }
 

--- a/inline-js-core/src/Language/JavaScript/Inline/Core.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Core.hs
@@ -29,6 +29,9 @@ module Language.JavaScript.Inline.Core
     export,
     exportSync,
 
+    -- * Manual resource management
+    freeJSVal,
+
     -- * Exceptions
     NodeVersionUnsupported (..),
     EvalError (..),
@@ -104,10 +107,11 @@ importMJS s p = do
 -- * When called in JavaScript, the Haskell function is run in a forked thread.
 -- * If the Haskell function throws, the JavaScript function will reject with an
 --   @Error@ with the exception string.
--- * Unlike 'JSVal's returned by 'eval', 'JSVal's returned by 'export' is not
+-- * Unlike 'JSVal's returned by 'eval', 'JSVal's returned by 'export' are not
 --   garbage collected, since we don't know when a function is garbage collected
---   on the @node@ side.
-export :: forall f. Export f => Session -> f -> IO JSVal
+--   on the @node@ side. These 'JSVal's need to be manually freed using
+--   'freeJSVal'.
+export :: Export f => Session -> f -> IO JSVal
 export = exportAsyncOrSync False
 
 -- | Export a Haskell function as a JavaScript sync function. This is quite
@@ -119,7 +123,7 @@ export = exportAsyncOrSync False
 -- is called, it blocks @node@ until the Haskell function produces the result or
 -- throws. If the Haskell function calls into JavaScript again, that call will
 -- be blocked infinitely without warning.
-exportSync :: forall f . Export f => Session -> f -> IO JSVal
+exportSync :: Export f => Session -> f -> IO JSVal
 exportSync = exportAsyncOrSync True
 
 string :: String -> JSExpr

--- a/inline-js-core/src/Language/JavaScript/Inline/Core/Class.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Core/Class.hs
@@ -80,4 +80,4 @@ instance FromJS JSVal where
   toRawJSType _ = "a => a"
   fromJS _session _jsval_id_buf = do
     _jsval_id <- runGetExact getWord64host _jsval_id_buf
-    newJSVal _jsval_id (sessionSend _session $ JSValFree _jsval_id)
+    newJSVal True _jsval_id (sessionSend _session $ JSValFree _jsval_id)

--- a/inline-js-core/src/Language/JavaScript/Inline/Core/Instruction.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Core/Instruction.hs
@@ -69,4 +69,6 @@ exportAsyncOrSync _is_sync _session@Session {..} f = do
         throwIO $ EvalError {evalErrorMessage = stringFromLBS _err_buf}
       Right _jsval_id_buf -> do
         _jsval_id <- runGetExact getWord64host _jsval_id_buf
-        newJSVal _jsval_id (pure ())
+        newJSVal False _jsval_id $ do
+          sessionSend _session $ JSValFree _jsval_id
+          freeStablePtr _sp_f

--- a/inline-js/tests/inline-js-tests.hs
+++ b/inline-js/tests/inline-js-tests.hs
@@ -70,7 +70,8 @@ main =
             let x = V $ A.String "asdf"
                 y = V $ A.String "233"
             r <- eval s [expr| $v($x, $y) |]
-            r @?= V (A.Array [A.String "asdf", A.String "233"]),
+            r @?= V (A.Array [A.String "asdf", A.String "233"])
+            freeJSVal v,
         testCase "exportSync" $
           withDefaultSession $ \s -> do
             let f :: V -> V -> IO V
@@ -80,6 +81,7 @@ main =
                 y = V $ A.String "233"
             r <- eval s [expr| $v($x, $y) |]
             r @?= V (A.Array [A.String "asdf", A.String "233"])
+            freeJSVal v
       ]
 
 newtype I = I Int


### PR DESCRIPTION
* `freeJSVal` is added to allow manual freeing of `JSVal`s; the `JSVal`s produced by `export`/`exportSync` are now attached with proper non-gc finalizers
* `embedFile` is now independent of ghc working directory, so `ghci` works properly at the project root directory
* `toJS` now avoids calling `vm.runInThisContext` when it discovers the `JSExpr` only contains a single non-code segment
* `onUncaughtException` now guarantees exiting `node` regardless of whether the `FatalError` message is sent successfully
* Add netlify badge to readme