### PR TITLE
Misc improvements

### DIFF
--- a/inline-js-core/jsbits/index.js
+++ b/inline-js-core/jsbits/index.js
@@ -11,7 +11,6 @@ class JSValContext {
   constructor() {
     this.jsvalMap = new Map();
     this.jsvalLast = 0n;
-    Object.seal(this);
   }
 
   new(x) {
@@ -66,7 +65,6 @@ class MainContext {
     });
     this.worker.on("message", (buf_msg) => this.onWorkerMessage(buf_msg));
     this.recvLoop();
-    Object.freeze(this);
   }
 
   recvLoop() {
@@ -143,7 +141,6 @@ class WorkerContext {
         this.onParentMessage(buf_msg)
       );
     })();
-    Object.freeze(this);
   }
 
   toJS(buf, p) {

--- a/inline-js-core/jsbits/index.js
+++ b/inline-js-core/jsbits/index.js
@@ -78,6 +78,10 @@ class MainContext {
         const buf_msg = buf.slice(8, 8 + len);
         buf = buf.slice(8 + len);
 
+        if (buf_msg.readUInt8(0) === 4) {
+          process.stdin.unref();
+        }
+
         Atomics.wait(this.exportSyncFlag, 0, 2);
         const export_sync_flag = Atomics.load(this.exportSyncFlag, 0);
 
@@ -87,10 +91,6 @@ class MainContext {
           Atomics.store(this.exportSyncFlag, 0, 2);
           Atomics.notify(this.exportSyncFlag, 0, 1);
           continue;
-        }
-
-        if (buf_msg.readUInt8(0) === 4) {
-          process.stdin.unref();
         }
 
         this.worker.postMessage(buf_msg);

--- a/inline-js-core/jsbits/index.js
+++ b/inline-js-core/jsbits/index.js
@@ -171,7 +171,7 @@ class WorkerContext {
           const buf_len = Number(buf.readBigUInt64LE(p));
           p += 8;
           const buf_id = jsval_tmp.push(buf.slice(p, p + buf_len)) - 1;
-          expr = `${expr}__t${buf_id.toString(36)}`;
+          expr = `${expr}__${buf_id}`;
           p += buf_len;
           break;
         }
@@ -182,7 +182,7 @@ class WorkerContext {
           p += 8;
           const str_id =
             jsval_tmp.push(this.decoder.end(buf.slice(p, p + buf_len))) - 1;
-          expr = `${expr}__t${str_id.toString(36)}`;
+          expr = `${expr}__${str_id}`;
           p += buf_len;
           break;
         }
@@ -195,7 +195,7 @@ class WorkerContext {
             jsval_tmp.push(
               JSON.parse(this.decoder.end(buf.slice(p, p + buf_len)))
             ) - 1;
-          expr = `${expr}__t${json_id.toString(36)}`;
+          expr = `${expr}__${json_id}`;
           p += buf_len;
           break;
         }
@@ -204,7 +204,7 @@ class WorkerContext {
           // JSValLiteral
           const jsval_id =
             jsval_tmp.push(this.jsval.get(buf.readBigUInt64LE(p))) - 1;
-          expr = `${expr}__t${jsval_id.toString(36)}`;
+          expr = `${expr}__${jsval_id}`;
           p += 8;
           break;
         }
@@ -222,7 +222,7 @@ class WorkerContext {
     } else {
       let expr_params = "require";
       for (let i = 0; i < jsval_tmp.length; ++i) {
-        expr_params = `${expr_params}, __t${i.toString(36)}`;
+        expr_params = `${expr_params}, __${i}`;
       }
       expr = `(${expr_params}) => (\n${expr}\n)`;
       result = vm.runInThisContext(expr, {

--- a/inline-js-core/jsbits/index.js
+++ b/inline-js-core/jsbits/index.js
@@ -509,7 +509,7 @@ function newPromise() {
 }
 
 function isPromise(obj) {
-  return obj && typeof obj.then === "function";
+  return Boolean(obj) && typeof obj.then === "function";
 }
 
 function bufferFromArrayBufferView(a) {

--- a/inline-js-core/src/Language/JavaScript/Inline/Core/Class.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Core/Class.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeFamilies #-}
 
@@ -7,6 +8,7 @@ module Language.JavaScript.Inline.Core.Class where
 import Data.Binary.Get
 import qualified Data.ByteString.Lazy as LBS
 import Data.Proxy
+import Data.String
 import Language.JavaScript.Inline.Core.JSVal
 import Language.JavaScript.Inline.Core.Message
 import Language.JavaScript.Inline.Core.Session
@@ -16,18 +18,21 @@ import Language.JavaScript.Inline.Core.Utils
 newtype EncodedString = EncodedString
   { unEncodedString :: LBS.ByteString
   }
-  deriving (Show)
+  deriving (Show, IsString)
 
 -- | UTF-8 encoded JSON.
 newtype EncodedJSON = EncodedJSON
   { unEncodedJSON :: LBS.ByteString
   }
-  deriving (Show)
+  deriving (Show, IsString)
 
 -- | Haskell types which can be converted to JavaScript.
 class ToJS a where
   -- | Encodes a Haskell value to 'JSExpr'.
   toJS :: a -> JSExpr
+
+instance ToJS () where
+  toJS _ = "undefined"
 
 instance ToJS LBS.ByteString where
   toJS = JSExpr . pure . BufferLiteral
@@ -56,7 +61,7 @@ class FromJS a where
 
 instance FromJS () where
   rawJSType _ = RawNone
-  toRawJSType _ = "a => a"
+  toRawJSType _ = "() => undefined"
   fromJS _ _ = pure ()
 
 instance FromJS LBS.ByteString where

--- a/inline-js-core/src/Language/JavaScript/Inline/Core/Instruction.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Core/Instruction.hs
@@ -128,8 +128,8 @@ exportAsyncOrSync _is_sync _session@Session {..} f = do
       Right _jsval_id_buf -> do
         _jsval_id <- runGetExact getWord64host _jsval_id_buf
         newJSVal False _jsval_id $ do
-          sessionSend _session $ JSValFree _jsval_id
           freeStablePtr _sp_f
+          sessionSend _session $ JSValFree _jsval_id
 
 -- | Export a Haskell function as a JavaScript async function, and return its
 -- 'JSVal'. Some points to keep in mind:

--- a/inline-js-core/src/Language/JavaScript/Inline/Core/Instruction.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Core/Instruction.hs
@@ -148,12 +148,16 @@ export = exportAsyncOrSync False
 
 -- | Export a Haskell function as a JavaScript sync function. This is quite
 -- heavyweight and in most cases, 'export' is preferrable. 'exportSync' can be
--- useful in certain scenarios when a sync function is desired, e.g. as
--- WebAssembly imports.
+-- useful in certain scenarios when a sync function is desired, e.g. converting
+-- a Haskell function to a WebAssembly import.
 --
--- Unlike 'export', 'exportSync' is not reentrant. When the JavaScript function
--- is called, it blocks @node@ until the Haskell function produces the result or
--- throws. If the Haskell function calls into JavaScript again, that call will
--- be blocked infinitely without warning.
+-- Unlike 'export', 'exportSync' has limited reentrancy:
+--
+-- * The Haskell function may calculate the return value based on the result of
+--   calling into JavaScript again, but only synchronous code is supported in
+--   this case.
+-- * The exported JavaScript sync function must not invoke other exported
+--   JavaScript sync functions, either directly or indirectly(Haskell calling
+--   into JavaScript again).
 exportSync :: Export f => Session -> f -> IO JSVal
 exportSync = exportAsyncOrSync True

--- a/inline-js-core/src/Language/JavaScript/Inline/Core/Instruction.hs
+++ b/inline-js-core/src/Language/JavaScript/Inline/Core/Instruction.hs
@@ -72,9 +72,9 @@ evalWithDecoder _return_type _decoder _session@Session {..} _code = do
 eval :: forall a. FromJS a => Session -> JSExpr -> IO a
 eval s c =
   evalWithDecoder (rawJSType (Proxy @a)) fromJS s $
-    "Promise.resolve("
+    "((x, f) => (Boolean(x) && typeof x.then === 'function') ? x.then(f) : f(x))("
       <> c
-      <> ").then("
+      <> ", "
       <> toRawJSType (Proxy @a)
       <> ")"
 

--- a/inline-js-examples/inline-js-examples.cabal
+++ b/inline-js-examples/inline-js-examples.cabal
@@ -4,7 +4,7 @@ cabal-version: 2.2
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 9f6f714054828ed848c01176353fea26cfa5b2266275d7c7df6bdb1cf4256921
+-- hash: 984be4683a1f47b1ff48e1e1f76e84fc11e815ab78c11a66aaabd2ba19e54762
 
 name:           inline-js-examples
 version:        0.0.1.0
@@ -29,7 +29,9 @@ source-repository head
 
 library
   exposed-modules:
+      Language.JavaScript.Inline.Examples.Stream
       Language.JavaScript.Inline.Examples.Utils
+      Language.JavaScript.Inline.Examples.Utils.LazyIO
       Language.JavaScript.Inline.Examples.Wasm
   other-modules:
       Paths_inline_js_examples
@@ -42,4 +44,6 @@ library
       base >=4.13 && <5
     , bytestring
     , inline-js
+    , stm
+    , stm-chans
   default-language: Haskell2010

--- a/inline-js-examples/package.yaml
+++ b/inline-js-examples/package.yaml
@@ -19,6 +19,8 @@ dependencies:
   - base >= 4.13 && < 5
   - bytestring
   - inline-js
+  - stm
+  - stm-chans
 
 library:
   source-dirs: src

--- a/inline-js-examples/src/Language/JavaScript/Inline/Examples/Stream.hs
+++ b/inline-js-examples/src/Language/JavaScript/Inline/Examples/Stream.hs
@@ -7,6 +7,7 @@ module Language.JavaScript.Inline.Examples.Stream where
 
 import Control.Exception
 import qualified Data.ByteString.Lazy as LBS
+import Data.Foldable
 import Language.JavaScript.Inline
 import Language.JavaScript.Inline.Examples.Utils.LazyIO
 
@@ -19,6 +20,7 @@ lazyStream _session _stream = do
     export
       _session
       (lazyOnError . toException . userError . show @EncodedString)
+  lazySetFinalizer $ for_ [_on_data, _on_end, _on_error] freeJSVal
   eval @()
     _session
     [block|

--- a/inline-js-examples/src/Language/JavaScript/Inline/Examples/Stream.hs
+++ b/inline-js-examples/src/Language/JavaScript/Inline/Examples/Stream.hs
@@ -1,0 +1,29 @@
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Language.JavaScript.Inline.Examples.Stream where
+
+import Control.Exception
+import qualified Data.ByteString.Lazy as LBS
+import Language.JavaScript.Inline
+import Language.JavaScript.Inline.Examples.Utils.LazyIO
+
+lazyStream :: Session -> JSVal -> IO LBS.ByteString
+lazyStream _session _stream = do
+  LazyIO {..} <- newLazyIO
+  _on_data <- export _session (lazyOnData . LBS.toStrict)
+  _on_end <- export _session lazyOnEnd
+  _on_error <-
+    export
+      _session
+      (lazyOnError . toException . userError . show @EncodedString)
+  eval @()
+    _session
+    [block|
+      $_stream.on("data", $_on_data);
+      $_stream.on("end", $_on_end);
+      $_stream.on("error", $_on_error);
+    |]
+  pure lazyContent

--- a/inline-js-examples/src/Language/JavaScript/Inline/Examples/Utils.hs
+++ b/inline-js-examples/src/Language/JavaScript/Inline/Examples/Utils.hs
@@ -17,6 +17,6 @@ storableToLBS a =
 
 storableFromLBS :: forall a. Storable a => LBS.ByteString -> IO a
 storableFromLBS s = BS.unsafeUseAsCStringLen (LBS.toStrict s) $ \(p, len) ->
-  if (len == sizeOf (undefined :: a))
+  if len == sizeOf (undefined :: a)
     then peek (castPtr p)
     else fail "Language.JavaScript.Inline.Examples.Utils.storableFromLBS"

--- a/inline-js-examples/src/Language/JavaScript/Inline/Examples/Utils/LazyIO.hs
+++ b/inline-js-examples/src/Language/JavaScript/Inline/Examples/Utils/LazyIO.hs
@@ -1,0 +1,38 @@
+{-# LANGUAGE StrictData #-}
+
+module Language.JavaScript.Inline.Examples.Utils.LazyIO where
+
+import Control.Concurrent.STM
+import Control.Concurrent.STM.TMQueue
+import Control.Exception
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy.Internal as LBS
+import System.IO.Unsafe
+
+data LazyIO = LazyIO
+  { lazyContent :: ~LBS.ByteString,
+    lazyOnData :: BS.ByteString -> IO (),
+    lazyOnEnd :: IO (),
+    lazyOnError :: SomeException -> IO ()
+  }
+
+newLazyIO :: IO LazyIO
+newLazyIO = do
+  q <- newTMQueueIO
+  let w = do
+        r <- atomically $ readTMQueue q
+        case r of
+          Just c -> do
+            cs <- unsafeInterleaveIO w
+            pure $ LBS.Chunk c cs
+          _ -> pure LBS.Empty
+  s <- unsafeInterleaveIO w
+  pure
+    LazyIO
+      { lazyContent = s,
+        lazyOnData = atomically . writeTMQueue q,
+        lazyOnEnd = atomically $ closeTMQueue q,
+        lazyOnError = \(SomeException err) -> atomically $ do
+          writeTMQueue q (throw err)
+          closeTMQueue q
+      }

--- a/inline-js-examples/src/Language/JavaScript/Inline/Examples/Utils/LazyIO.hs
+++ b/inline-js-examples/src/Language/JavaScript/Inline/Examples/Utils/LazyIO.hs
@@ -1,19 +1,23 @@
 {-# LANGUAGE StrictData #-}
+{-# LANGUAGE TupleSections #-}
 
 module Language.JavaScript.Inline.Examples.Utils.LazyIO where
 
 import Control.Concurrent.STM
 import Control.Concurrent.STM.TMQueue
 import Control.Exception
+import Control.Monad
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy.Internal as LBS
+import Data.IORef
 import System.IO.Unsafe
 
 data LazyIO = LazyIO
   { lazyContent :: ~LBS.ByteString,
     lazyOnData :: BS.ByteString -> IO (),
     lazyOnEnd :: IO (),
-    lazyOnError :: SomeException -> IO ()
+    lazyOnError :: SomeException -> IO (),
+    lazySetFinalizer :: IO () -> IO ()
   }
 
 newLazyIO :: IO LazyIO
@@ -27,12 +31,19 @@ newLazyIO = do
             pure $ LBS.Chunk c cs
           _ -> pure LBS.Empty
   s <- unsafeInterleaveIO w
+  fin_ref <- newIORef (pure ())
+  let fin = join $ atomicModifyIORef' fin_ref (pure (),)
   pure
     LazyIO
       { lazyContent = s,
         lazyOnData = atomically . writeTMQueue q,
-        lazyOnEnd = atomically $ closeTMQueue q,
-        lazyOnError = \(SomeException err) -> atomically $ do
-          writeTMQueue q (throw err)
-          closeTMQueue q
+        lazyOnEnd = do
+          atomically $ closeTMQueue q
+          fin,
+        lazyOnError = \(SomeException err) -> do
+          atomically $ do
+            writeTMQueue q (throw err)
+            closeTMQueue q
+          fin,
+        lazySetFinalizer = atomicWriteIORef fin_ref
       }

--- a/inline-js-tests/inline-js-tests.cabal
+++ b/inline-js-tests/inline-js-tests.cabal
@@ -4,7 +4,7 @@ cabal-version: 2.2
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: ccbf7eb1e66c07b8032f6583a639d48e7a40a873b8bf00d04c44e79efa50b08c
+-- hash: 80760900943ce048a1978948f69de735a0f1f55cd07873ca761525562820e156
 
 name:           inline-js-tests
 version:        0.0.1.0
@@ -38,8 +38,7 @@ test-suite inline-js-tests
       tests
   ghc-options: -Wall -threaded -rtsopts
   build-depends:
-      Cabal
-    , aeson
+      aeson
     , base >=4.13 && <5
     , bytestring
     , directory

--- a/inline-js-tests/inline-js-tests.cabal
+++ b/inline-js-tests/inline-js-tests.cabal
@@ -4,7 +4,7 @@ cabal-version: 2.2
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 0b17b7111eb319490e0c96140991803fff480705bb6eb951ee5b33e194e2cef5
+-- hash: ccbf7eb1e66c07b8032f6583a639d48e7a40a873b8bf00d04c44e79efa50b08c
 
 name:           inline-js-tests
 version:        0.0.1.0
@@ -47,6 +47,8 @@ test-suite inline-js-tests
     , inline-js
     , inline-js-examples
     , process
+    , splitmix
     , tasty
     , tasty-hunit
+    , temporary
   default-language: Haskell2010

--- a/inline-js-tests/package.yaml
+++ b/inline-js-tests/package.yaml
@@ -25,8 +25,10 @@ dependencies:
   - inline-js
   - inline-js-examples
   - process
+  - splitmix
   - tasty
   - tasty-hunit
+  - temporary
 
 tests:
   inline-js-tests:

--- a/inline-js-tests/package.yaml
+++ b/inline-js-tests/package.yaml
@@ -16,7 +16,6 @@ extra-source-files:
 ghc-options: -Wall -threaded -rtsopts
 
 dependencies:
-  - Cabal
   - aeson
   - base >= 4.13 && < 5
   - bytestring

--- a/inline-js-tests/tests/inline-js-tests.hs
+++ b/inline-js-tests/tests/inline-js-tests.hs
@@ -82,7 +82,7 @@ main =
         testCase "exportSync" $
           withDefaultSession $ \s -> replicateM_ 0x10 $ do
             let f :: V -> V -> IO V
-                f (V x) (V y) = pure $ V $ A.Array [x, y]
+                f x y = eval s [expr| [$x, $y] |]
             v <- exportSync s f
             let x = V $ A.String "asdf"
                 y = V $ A.String "233"

--- a/inline-js-tests/tests/inline-js-tests.hs
+++ b/inline-js-tests/tests/inline-js-tests.hs
@@ -11,14 +11,19 @@ import Control.Monad
 import qualified Data.Aeson as A
 import qualified Data.ByteString.Lazy as LBS
 import Data.Foldable
-import Distribution.Simple.Utils
+import Foreign
 import Language.JavaScript.Inline
+import Language.JavaScript.Inline.Examples.Stream
 import System.Directory
 import System.Exit
 import System.FilePath
+import System.IO
+import System.IO.Temp
 import System.Process
+import System.Random.SplitMix
 import Test.Tasty
 import Test.Tasty.HUnit
+import Data.String
 
 main :: IO ()
 main =
@@ -88,7 +93,21 @@ main =
                 y = V $ A.String "233"
             r <- eval s [expr| $v($x, $y) |]
             r @?= V (A.Array [A.String "asdf", A.String "233"])
-            freeJSVal v
+            freeJSVal v,
+        testCase "stream" $
+          withDefaultSession $ \s ->
+            bracket (randomFile 0x100000) removeFile $ \p -> do
+              let js_path = fromString @EncodedString p
+              js_stream <-
+                eval
+                  s
+                  [block|
+                    const fs = require("fs");
+                    return fs.createReadStream($js_path);
+                  |]
+              js_content <- lazyStream s js_stream
+              hs_content <- LBS.readFile p
+              js_content @?= hs_content
       ]
 
 newtype I = I Int
@@ -115,3 +134,20 @@ withTmpDir pre =
         pure p
     )
     removePathForcibly
+
+randomFile :: Int -> IO FilePath
+randomFile size = do
+  tmpdir <- getCanonicalTemporaryDirectory
+  (p, h) <- openBinaryTempFile tmpdir "inline-js"
+  gen <- newSMGen
+  alloca $ \ptr ->
+    let w _gen _size
+          | _size >= 8 = do
+            let (x, _gen') = nextWord64 _gen
+            poke ptr x
+            hPutBuf h ptr 8
+            w _gen' (_size - 8)
+          | otherwise = pure ()
+     in w gen size
+  hClose h
+  pure p


### PR DESCRIPTION
* Support reentrancy in sync mode of Haskell function exporting. The Haskell function may call into JavaScript again, as long as the result will be available synchronously.
* Add `Stream` example and test it. It converts a JavaScript `ReadableStream` to Haskell lazy `ByteString`.
* Fix `ToJS`/`FromJS` instance of `()`.
* Add `IsString` instance for `EncodedString`/`EncodedJSON`.