### PR TITLE
Unify expr/block TH quasi-quoters

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -33,7 +33,7 @@ jobs:
       - name: setup-cachix
         uses: cachix/cachix-action@master
         with:
-          name: inline-js
+          name: asterius
           signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
 
       - name: test
@@ -128,7 +128,7 @@ jobs:
       - name: setup-cachix
         uses: cachix/cachix-action@master
         with:
-          name: inline-js
+          name: asterius
           signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
 
       - name: sdist
@@ -162,7 +162,7 @@ jobs:
       - name: setup-cachix
         uses: cachix/cachix-action@master
         with:
-          name: inline-js
+          name: asterius
           signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
 
       - name: haddock

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os:
           - ubuntu-20.04
-          - macos-11.0
+          - macos-10.15
         ghc:
           - ghc8102
           - ghc884

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os:
           - ubuntu-20.04
-          - macos-10.15
+          - macos-11.0
         ghc:
           - ghc8102
           - ghc884

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Supported platforms:
 
 - Windows 10 x64, tested with Windows Server 2019
 - Linux x64, tested with Ubuntu 20.04
-- macOS x64, tested with macOS 11.0
+- macOS x64, tested with macOS 10.15
 
 Supported `node` versions:
 

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ Supported GHC versions:
 Supported platforms:
 
 - Windows 10 x64, tested with Windows Server 2019
-- Linux x64, tested with Ubuntu focal
-- macOS x64, tested with macOS Catalina
+- Linux x64, tested with Ubuntu 20.04
+- macOS x64, tested with macOS 11.0
 
 Supported `node` versions:
 

--- a/cabal.project
+++ b/cabal.project
@@ -4,4 +4,4 @@ packages:
   inline-js-examples
   inline-js-tests
 
-index-state: 2020-10-16T00:00:00Z
+index-state: 2020-10-17T00:00:00Z

--- a/inline-js-examples/src/Language/JavaScript/Inline/Examples/Stream.hs
+++ b/inline-js-examples/src/Language/JavaScript/Inline/Examples/Stream.hs
@@ -23,7 +23,7 @@ lazyStream _session _stream = do
   lazySetFinalizer $ for_ [_on_data, _on_end, _on_error] freeJSVal
   eval @()
     _session
-    [block|
+    [js|
       $_stream.on("data", $_on_data);
       $_stream.on("end", $_on_end);
       $_stream.on("error", $_on_error);

--- a/inline-js-examples/src/Language/JavaScript/Inline/Examples/Wasm.hs
+++ b/inline-js-examples/src/Language/JavaScript/Inline/Examples/Wasm.hs
@@ -24,43 +24,43 @@ newtype F64 = F64 Double
   deriving (Show, Storable) via Double
 
 instance ToJS I32 where
-  toJS x = [expr| $buf.readUInt32LE() |] where buf = storableToLBS x
+  toJS x = [js| $buf.readUInt32LE() |] where buf = storableToLBS x
 
 instance FromJS I32 where
   rawJSType _ = RawBuffer
   toRawJSType _ =
-    [expr| x => { const buf = Buffer.allocUnsafe(4); buf.writeUInt32LE(x); return buf; } |]
+    [js| x => { const buf = Buffer.allocUnsafe(4); buf.writeUInt32LE(x); return buf; } |]
   fromJS _ = storableFromLBS
 
 instance ToJS I64 where
-  toJS x = [expr| $buf.readBigUInt64LE() |] where buf = storableToLBS x
+  toJS x = [js| $buf.readBigUInt64LE() |] where buf = storableToLBS x
 
 instance FromJS I64 where
   rawJSType _ = RawBuffer
   toRawJSType _ =
-    [expr| x => { const buf = Buffer.allocUnsafe(8); buf.writeBigUInt64LE(x); return buf; } |]
+    [js| x => { const buf = Buffer.allocUnsafe(8); buf.writeBigUInt64LE(x); return buf; } |]
   fromJS _ = storableFromLBS
 
 instance ToJS F32 where
-  toJS x = [expr| $buf.readFloatLE() |] where buf = storableToLBS x
+  toJS x = [js| $buf.readFloatLE() |] where buf = storableToLBS x
 
 instance FromJS F32 where
   rawJSType _ = RawBuffer
   toRawJSType _ =
-    [expr| x => { const buf = Buffer.allocUnsafe(4); buf.writeFloatLE(x); return buf; } |]
+    [js| x => { const buf = Buffer.allocUnsafe(4); buf.writeFloatLE(x); return buf; } |]
   fromJS _ = storableFromLBS
 
 instance ToJS F64 where
-  toJS x = [expr| $buf.readDoubleLE() |] where buf = storableToLBS x
+  toJS x = [js| $buf.readDoubleLE() |] where buf = storableToLBS x
 
 instance FromJS F64 where
   rawJSType _ = RawBuffer
   toRawJSType _ =
-    [expr| x => { const buf = Buffer.allocUnsafe(8); buf.writeDoubleLE(x); return buf; } |]
+    [js| x => { const buf = Buffer.allocUnsafe(8); buf.writeDoubleLE(x); return buf; } |]
   fromJS _ = storableFromLBS
 
 importNew :: Session -> IO JSVal
-importNew _session = eval _session [expr| {} |]
+importNew _session = eval _session [js| {} |]
 
 importAdd :: Export f => Session -> JSVal -> String -> String -> f -> IO ()
 importAdd _session _import_obj (Aeson -> _import_module) (Aeson -> _import_name) _import_hs_func =
@@ -69,7 +69,7 @@ importAdd _session _import_obj (Aeson -> _import_module) (Aeson -> _import_name)
     evaluate
       =<< eval
         _session
-        [block|
+        [js|
           if (!($_import_obj[$_import_module])) {
             $_import_obj[$_import_module] = {};
           }
@@ -78,13 +78,13 @@ importAdd _session _import_obj (Aeson -> _import_module) (Aeson -> _import_name)
 
 wasmCompile :: Session -> LBS.ByteString -> IO JSVal
 wasmCompile _session _module_buf =
-  eval _session [expr| WebAssembly.compile($_module_buf) |]
+  eval _session [js| WebAssembly.compile($_module_buf) |]
 
 wasmInstantiate :: Session -> JSVal -> JSVal -> IO JSVal
 wasmInstantiate _session _module _import_obj =
-  eval _session [expr| WebAssembly.instantiate($_module, $_import_obj) |]
+  eval _session [js| WebAssembly.instantiate($_module, $_import_obj) |]
 
 exportGet :: Import f => Session -> JSVal -> String -> IO f
 exportGet _session _instance (Aeson -> _export_name) = do
-  _export_js_func <- eval _session [expr| $_instance.exports[$_export_name] |]
+  _export_js_func <- eval _session [js| $_instance.exports[$_export_name] |]
   pure $ importJSFunc _session _export_js_func

--- a/inline-js-tests/app/inline-js-tests.hs
+++ b/inline-js-tests/app/inline-js-tests.hs
@@ -67,11 +67,11 @@ main =
           withDefaultSession $ \s -> replicateM_ 0x10 $ do
             let x = I 6
                 y = I 7
-            r <- eval s [expr| $x * $y |]
+            r <- eval s [js| $x * $y |]
             r @?= I 42,
         testCase "import" $
           withDefaultSession $ \s -> replicateM_ 0x10 $ do
-            v <- eval s [expr| (x, y) => x * y |]
+            v <- eval s [js| (x, y) => x * y |]
             let f = importJSFunc s v
             r <- f (I 6) (I 7)
             r @?= I 42,
@@ -82,17 +82,17 @@ main =
             v <- export s f
             let x = V $ A.String "asdf"
                 y = V $ A.String "233"
-            r <- eval s [expr| $v($x, $y) |]
+            r <- eval s [js| $v($x, $y) |]
             r @?= V (A.Array [A.String "asdf", A.String "233"])
             freeJSVal v,
         testCase "exportSync" $
           withDefaultSession $ \s -> replicateM_ 0x10 $ do
             let f :: V -> V -> IO V
-                f x y = eval s [expr| [$x, $y] |]
+                f x y = eval s [js| [$x, $y] |]
             v <- exportSync s f
             let x = V $ A.String "asdf"
                 y = V $ A.String "233"
-            r <- eval s [expr| $v($x, $y) |]
+            r <- eval s [js| $v($x, $y) |]
             r @?= V (A.Array [A.String "asdf", A.String "233"])
             freeJSVal v,
         testCase "stream" $
@@ -102,7 +102,7 @@ main =
               js_stream <-
                 eval
                   s
-                  [block|
+                  [js|
                     const fs = require("fs");
                     return fs.createReadStream($js_path);
                   |]

--- a/inline-js/inline-js.cabal
+++ b/inline-js/inline-js.cabal
@@ -4,7 +4,7 @@ cabal-version: 2.2
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 14dc67d6e9b3140007c2cb8324d3fbc205387df94462dcd004edbb9c0348e70a
+-- hash: bd451d42840decd8b5acd66cbfd3b0abe47362280f2d037214043178efce7704
 
 name:           inline-js
 version:        0.0.1.0
@@ -32,6 +32,7 @@ library
       Language.JavaScript.Inline
   other-modules:
       Language.JavaScript.Inline.Aeson
+      Language.JavaScript.Inline.JSParse
       Language.JavaScript.Inline.TH
       Paths_inline_js
   autogen-modules:
@@ -43,7 +44,9 @@ library
       aeson
     , base >=4.13 && <5
     , bytestring
+    , containers
     , inline-js-core
     , language-javascript
+    , syb
     , template-haskell
   default-language: Haskell2010

--- a/inline-js/package.yaml
+++ b/inline-js/package.yaml
@@ -19,8 +19,10 @@ dependencies:
   - aeson
   - base >= 4.13 && < 5
   - bytestring
+  - containers
   - inline-js-core
   - language-javascript
+  - syb
   - template-haskell
 
 library:

--- a/inline-js/src/Language/JavaScript/Inline.hs
+++ b/inline-js/src/Language/JavaScript/Inline.hs
@@ -6,10 +6,8 @@ module Language.JavaScript.Inline
     Aeson (..),
 
     -- * QuasiQuoters for inline JavaScript
-    expr,
-    block,
-    exprAsync,
-    blockAsync,
+    js,
+    jsAsync,
   )
 where
 

--- a/inline-js/src/Language/JavaScript/Inline/JSParse.hs
+++ b/inline-js/src/Language/JavaScript/Inline/JSParse.hs
@@ -1,0 +1,34 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Language.JavaScript.Inline.JSParse
+  ( jsParse,
+  )
+where
+
+import Data.Generics
+  ( GenericQ,
+    everything,
+  )
+import qualified Data.Set as S
+import Language.JavaScript.Parser
+import Language.JavaScript.Parser.Grammar7
+import Language.JavaScript.Parser.Parser
+import Type.Reflection
+
+jsParse :: String -> Either String (Bool, [String])
+jsParse src
+  | Right ast <- parseUsing parseExpression src "src" = Right (True, hsVars ast)
+  | otherwise = case parse src "src" of
+    Left err -> Left err
+    Right ast -> Right (False, hsVars ast)
+
+hsVars :: GenericQ [String]
+hsVars = S.toList . everything (<>) w
+  where
+    w :: GenericQ (S.Set String)
+    w t
+      | Just HRefl <- eqTypeRep (typeOf t) (typeRep @JSExpression) = case t of
+        JSIdentifier _ ('$' : v) -> S.singleton v
+        _ -> mempty
+      | otherwise = mempty

--- a/inline-js/src/Language/JavaScript/Inline/TH.hs
+++ b/inline-js/src/Language/JavaScript/Inline/TH.hs
@@ -2,13 +2,12 @@
 
 module Language.JavaScript.Inline.TH where
 
-import Data.Foldable
 import Data.List
 import Data.String
 import Language.Haskell.TH
 import Language.Haskell.TH.Quote
 import Language.JavaScript.Inline.Core
-import Language.JavaScript.Parser.Lexer
+import Language.JavaScript.Inline.JSParse
 
 -- | Generate a 'JSExpr' from an inline JavaScript expression. Use @$var@ to
 -- refer to a Haskell variable @var@ (its type should be an 'ToJS' instance).
@@ -38,30 +37,50 @@ fromQuoteExp q =
     }
 
 exprQuoter :: String -> Q Exp
-exprQuoter js_code = blockQuoter $ "return " <> js_code <> ";"
+exprQuoter = asdf False
 
 blockQuoter :: String -> Q Exp
-blockQuoter js_code =
-  [|fromString "(() => { " <> $(jsCodeHeader js_code) <> fromString $(litE $ stringL $ js_code <> " })()")|]
+blockQuoter = asdf False
 
 exprAsyncQuoter :: String -> Q Exp
-exprAsyncQuoter js_code = blockAsyncQuoter $ "return " <> js_code <> ";"
+exprAsyncQuoter = asdf True
 
 blockAsyncQuoter :: String -> Q Exp
-blockAsyncQuoter js_code =
-  [|fromString "(async () => { " <> $(jsCodeHeader js_code) <> fromString $(litE $ stringL $ js_code <> " })()")|]
+blockAsyncQuoter = asdf True
 
-jsCodeHeader :: String -> Q Exp
-jsCodeHeader js_code = do
-  tokens <- case alexTestTokeniser js_code of
-    Left err -> fail err
-    Right tokens -> pure tokens
-  let vars = nub [var | IdentifierToken {tokenLiteral = '$' : var} <- tokens]
-      js_code_header =
-        foldr'
-          (\m0 m1 -> [|$(m0) <> $(m1)|])
-          [|(mempty :: JSExpr)|]
-          [ [|fromString $(litE $ stringL $ "const $" <> var <> " = ") <> toJS $(varE $ mkName var) <> fromString "; "|]
-            | var <- vars
-          ]
-  js_code_header
+asdf :: Bool -> String -> Q Exp
+asdf is_async js_code = do
+  (is_expr, hs_vars) <-
+    case jsParse js_code of
+      Left err -> fail err
+      Right r -> pure r
+  [|
+    mconcat
+      $( listE
+           ( [ [|
+                 fromString
+                   $( litE
+                        ( stringL
+                            ( ( if is_async
+                                  then "(async ("
+                                  else "(("
+                              )
+                                <> intercalate "," ['$' : v | v <- hs_vars]
+                                <> ") => {"
+                                <> ( if is_expr
+                                       then "return " <> js_code <> ";"
+                                       else js_code
+                                   )
+                                <> "})("
+                            )
+                        )
+                    )
+                 |]
+             ]
+               <> intersperse
+                 [|fromString ","|]
+                 [[|toJS $(varE (mkName v))|] | v <- hs_vars]
+               <> [[|fromString ")"|]]
+           )
+       )
+    |]

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "f8443bf2ae2240fdc233eaa435220bfb679d2ef4",
-        "sha256": "1iv19hkdbzbs2vlc9qciak2imbpf6v7pqpypc3ivd8hkdvv2vf0w",
+        "rev": "3beaf26583d268e08707e0ad2ba9b186b33dc61a",
+        "sha256": "18pjlsh1c5jdn1s23lb6bnxhrf1ckhkbkh46vxyv8js239zdmp68",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/f8443bf2ae2240fdc233eaa435220bfb679d2ef4.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/3beaf26583d268e08707e0ad2ba9b186b33dc61a.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "niv": {


### PR DESCRIPTION
This PR unifies `expr`/`block` TH quasi-quoters to a single `js` quasi-quoter. `js` will attempt to parse the inline JS code as a single expression, and then fall back to parsing as a whole script if that fails. This leads to a cleaner and more uniform API.